### PR TITLE
Fix postinstall for SignalK App Store installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "scripts": {


### PR DESCRIPTION
Handle npm dependency hoisting when installed via SignalK App Store. npm hoists @marineyachtradar/mayara-gui to the parent node_modules directory instead of nesting it inside the plugin's node_modules.

The build script now searches multiple locations:
- Nested: <plugin>/node_modules/@marineyachtradar/mayara-gui
- Hoisted: <plugin>/../mayara-gui (works for both App Store and dev)
- Top-level: <plugin>/../../@marineyachtradar/mayara-gui