### PR TITLE
chore: declare signalk-container in signalk.requires

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,10 @@
       "name": "MaYaRa Radar",
       "description": "Marine radar display connected to mayara-server",
       "location": "/plugins/@marineyachtradar/signalk-plugin/"
-    }
+    },
+    "requires": [
+      "signalk-container"
+    ]
   },
   "files": [
     "plugin/**/*",


### PR DESCRIPTION
## Summary
- Add `signalk.requires: ["signalk-container"]` to package.json so the Signal K App Store surfaces the dependency, matching the pattern used by signalk-questdb.
- The npm `peerDependencies` / `peerDependenciesMeta` (optional) entry was already in place.

## Tested
- `git diff` shows only the four-line addition inside the `signalk` block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin dependencies to ensure compatibility and proper functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->