### PR TITLE
ci: switch to upstream SignalK reusable workflow + add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    ignore:
+      # @types/node major versions track the Node.js major. Keep this pinned
+      # to the lowest supported runtime (Node 20 per package.json engines)
+      # so types reflect what's actually available on every supported version.
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/signalk-ci.yml
+++ b/.github/workflows/signalk-ci.yml
@@ -1,11 +1,17 @@
-name: SignalK Plugin CI
+# Temporary — testing the new SignalK Plugin CI reusable workflow
+# from dirkwa/signalk-server PR #2400
+# Remove this file once the PR is merged and use the caller example instead
+
+name: Test SignalK Plugin CI
 
 on:
   push:
-    branches: [main, master]
-  pull_request:
-    branches: [main, master]
+    branches: [main]
+  workflow_dispatch:
 
 jobs:
   test:
-    uses: dirkwa/signalk-server/.github/workflows/plugin-ci.yml@feat-ci-for-plugins
+    uses: SignalK/signalk-server/.github/workflows/plugin-ci.yml@master
+    with:
+      enable-armv7: false
+      enable-signalk-integration: true


### PR DESCRIPTION
## Summary
- Point `.github/workflows/signalk-ci.yml` at the upstream `SignalK/signalk-server/.github/workflows/plugin-ci.yml@master` reusable workflow (was the `dirkwa` fork on the `feat-ci-for-plugins` branch). Mirrors the setup in [signalk-charts-provider-simple](https://github.com/dirkwa/signalk-charts-provider-simple/blob/main/.github/workflows/signalk-ci.yml).
- `enable-armv7: false` — mayara does not run on armv7 (no Cerbo GX target).
- `enable-signalk-integration: true`.
- Trigger changed to `push` on `main` + `workflow_dispatch` only (no `pull_request`), matching the charts-provider workflow.
- Add `.github/dependabot.yml` mirroring charts-provider: weekly npm + github-actions updates, grouped minor/patch, `@types/node` major pinned to the lowest supported Node (20 here).

## Tested
- Local diff verified against the charts-provider files.
- Workflow will run on merge to `main` (push trigger). No PR-time CI by design — this is the upstream pattern.