### PR TITLE
chore(release): 0.5.6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,30 +5,51 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  id-token: write
-  contents: read
-
 jobs:
+  release:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-beta.') || contains(github.ref_name, '-rc.') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   publish:
-    runs-on: ubuntu-latest
+    needs: release
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Clean workspace
         run: git clean -xfd
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Update npm
-        run: npm install -g npm@latest
       - run: npm install
 
-      - run: npm test
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
 
       - name: Publish
         run: |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A SignalK plugin that connects to [mayara-server](https://github.com/MarineYacht
 
 ## Prerequisites
 
-- **SignalK Server ≥ 2.24.0** with the Radar API — **PR [SignalK/signalk-server#2357](https://github.com/SignalK/signalk-server/pull/2357)**
+- **SignalK Server ≥ 2.24.0** (the Radar API ships in 2.24.0+)
 - **Node.js ≥ 20** (matches signalk-server 2.24.0 baseline; tested on Node 22 and 24, also works on Cerbo GX with Node 20)
 - **[signalk-container](https://github.com/dirkwa/signalk-container) ≥ 0.1.6** (for managed container mode, optional)
 - **Podman** or **Docker** runtime (for managed container mode)
@@ -133,7 +133,7 @@ npm run build
 
 - **[mayara-server](https://github.com/MarineYachtRadar/mayara-server)** — Standalone radar server
 - **[signalk-container](https://github.com/dirkwa/signalk-container)** — Container manager for SignalK
-- **[signalk-server#2357](https://github.com/SignalK/signalk-server/pull/2357)** — Radar API for SignalK server
+- **[Signal K Server](https://github.com/SignalK/signalk-server)** ≥ 2.24.0 — provides the Radar API
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.5.6",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
+  "signalk-plugin-enabled-by-default": true,
   "scripts": {
     "format": "prettier --write 'src/**/*.ts' 'test/**/*.ts' && eslint --fix 'src/**/*.ts' 'test/**/*.ts'",
     "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
Release 0.5.6. Bundles five changes since 0.5.5:

- #10 — declare `signalk-container` in `signalk.requires` so the App Store surfaces the dependency.
- #11 — switch CI to the upstream `SignalK/signalk-server` reusable workflow on master and add weekly dependabot.
- README: drop the merged-PR caveat — `SignalK/signalk-server#2357` shipped in server 2.24.0, so the requirement reads cleanly as "Signal K ≥ 2.24.0".
- `publish.yml`: add a GitHub Release job with auto-generated notes (mirrors signalk-charts-provider-simple). Action versions bumped to `checkout@v6` / `setup-node@v6`, publish runner moved to Node 24, manual `npm install -g npm@latest` step dropped. OIDC trusted publishing preserved.
- **Auto-enable on first install**: add `signalk-plugin-enabled-by-default: true` to package.json. New installs get the plugin running with schema defaults (managed container, latest tag) without requiring the user to flip the enable toggle. Once the user explicitly enables/disables, the saved choice wins — this only affects the first-install experience.

## Tested
- `npm run format` clean
- `npm run build:all` (lint + tsc + webpack + vitest) — 39/39 tests pass locally on Node 22.
- workflow_dispatch run against this branch confirmed the upstream CI matrix is green (no pull_request trigger on the new workflow).
- `publish.yml` change will be exercised when the v0.5.6 tag is pushed.