### PR TITLE
chore: drop Node 20 / Cerbo GX support claim

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
           - patch
     ignore:
       # @types/node major versions track the Node.js major. Keep this pinned
-      # to the lowest supported runtime (Node 20 per package.json engines)
+      # to the lowest supported runtime (Node 22 per package.json engines)
       # so types reflect what's actually available on every supported version.
       - dependency-name: '@types/node'
         update-types: ['version-update:semver-major']

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A SignalK plugin that connects to [mayara-server](https://github.com/MarineYacht
 ## Prerequisites
 
 - **SignalK Server ≥ 2.24.0** (the Radar API ships in 2.24.0+)
-- **Node.js ≥ 20** (matches signalk-server 2.24.0 baseline; tested on Node 22 and 24, also works on Cerbo GX with Node 20)
+- **Node.js ≥ 22** (tested on Node 22 and 24)
 - **[signalk-container](https://github.com/dirkwa/signalk-container) ≥ 0.1.6** (for managed container mode, optional)
 - **Podman** or **Docker** runtime (for managed container mode)
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "public/**/*"
   ],
   "engines": {
-    "node": ">=20",
+    "node": ">=22",
     "signalk": ">=2.24.0"
   },
   "dependencies": {
@@ -60,7 +60,7 @@
     "@eslint/js": "^9.0.0",
     "@signalk/server-api": "^2.24.0",
     "@types/express": "^5.0.0",
-    "@types/node": "^20.0.0",
+    "@types/node": "^22.0.0",
     "@types/ws": "^8.5.0",
     "eslint": "^9.26.0",
     "eslint-config-prettier": "^10.0.0",


### PR DESCRIPTION
## Summary
The plugin claims Node 20 / Cerbo GX support in the README and `engines`, but the CI matrix only runs Node 22 and 24 (`enable-armv7: false` in `signalk-ci.yml`). The claim was untested and misleading — raise the floor to Node 22 to match what we actually verify.

Four locations updated:
- README prerequisites line (drop Cerbo mention).
- `package.json` `engines.node`: `>=20` → `>=22`.
- `package.json` `@types/node`: `^20` → `^22`.
- `.github/dependabot.yml` comment that referenced the Node 20 pin.

No source changes.

## Tested
- `npm install` clean on the new `@types/node`.
- `npm run build:all` — 40/40 tests pass on Node 22.