### PR TITLE
chore(release): 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "0.5.7",
+  "version": "0.6.0",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "signalk-plugin-enabled-by-default": true,


### PR DESCRIPTION
## Summary
Release 0.6.0. Three changes since 0.5.7:

- #14 — add `AGENTS.md` / `CLAUDE.md` with the one-PR-per-change rule and other repo-specific guidance for AI coding agents.
- #15 — drop the Node 20 / Cerbo GX support claim. The CI matrix only runs Node 22 and 24 (`enable-armv7: false`); the previous `engines.node: >=20` was untested. Bumped to `>=22` everywhere (engines, `@types/node`, README, dependabot comment).
- #16 — add a plugin screenshot referenced from `package.json` `signalk.screenshots`, matching the signalk-app-dock convention. Ships in the npm tarball via `docs/**/*` in `files`.

`0.6.0` rather than `0.5.8` because the `engines.node` floor moved up — anyone on Node 20 will get an `EBADENGINE` install warning.

## Tested
- `npm run build:all` — 40/40 tests pass on Node 22.
- `npm pack --dry-run` — screenshot is in the tarball.