### PR TITLE
fix(container): recreate when ContainerConfig changes

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -311,6 +311,7 @@ module.exports = function (app) {
             tag: config.tag,
             command: config.command,
             networkMode: config.networkMode,
+            restart: config.restart,
             resources: config.resources
         });
     }
@@ -364,7 +365,17 @@ module.exports = function (app) {
             await containers.remove(CONTAINER_NAME);
         }
         await containers.ensureRunning(CONTAINER_NAME, config);
-        (0, fs_1.writeFileSync)(hashFile, configHash);
+        try {
+            (0, fs_1.writeFileSync)(hashFile, configHash);
+        }
+        catch (hashErr) {
+            // Non-fatal: a failed hash write just means the next plugin
+            // restart will recompute drift and recreate the container
+            // even though nothing actually changed. Log and continue so a
+            // disk-full / read-only-fs condition doesn't take down the
+            // whole plugin start.
+            app.debug(`Failed to persist container-hash: ${errMsg(hashErr)}`);
+        }
         // Register with the centralized update service. The service auto-
         // detects whether `tag` is a semver pin (compare via GitHub releases)
         // or a floating tag like `latest`/`main` (digest drift detection).

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+const fs_1 = require("fs");
 const mayara_client_1 = require("./mayara-client");
 const radar_provider_1 = require("./radar-provider");
 const spoke_forwarder_1 = require("./spoke-forwarder");
@@ -191,14 +192,26 @@ module.exports = function (app) {
                     // no way to roll back to the previous state — the old container's
                     // ID and config are gone. Surface a clear error so the user knows
                     // they need to retry the apply rather than seeing a generic 500.
+                    const newConfig = buildContainerConfig(tag);
                     try {
-                        await containers.ensureRunning(CONTAINER_NAME, buildContainerConfig(tag));
+                        await containers.ensureRunning(CONTAINER_NAME, newConfig);
                     }
                     catch (recreateErr) {
                         const msg = `Container removed but recreation failed: ${errMsg(recreateErr)}. Click Update again to retry.`;
                         app.setPluginError(msg);
                         res.status(500).json({ error: msg });
                         return;
+                    }
+                    // Refresh the hash file so the next plugin restart sees
+                    // matching config and doesn't trigger a redundant recreate
+                    // in startManagedContainer().
+                    try {
+                        (0, fs_1.writeFileSync)(`${app.getDataDirPath()}.container-hash`, computeConfigHash(newConfig));
+                    }
+                    catch (hashErr) {
+                        // Non-fatal: a stale hash will just cause one extra recreate
+                        // on the next plugin restart. Log and continue.
+                        app.debug(`Failed to refresh container-hash: ${errMsg(hashErr)}`);
                     }
                     // Persist the new tag to disk so a plugin restart doesn't roll
                     // back to the previous version. We update the in-memory copy
@@ -288,6 +301,19 @@ module.exports = function (app) {
             resources: DEFAULT_RESOURCES
         };
     }
+    // Stable JSON of every ContainerConfig field that affects the
+    // resulting `podman run` invocation. Used by both startup and the
+    // /api/update/apply route so they can never drift on what counts
+    // as a "config change".
+    function computeConfigHash(config) {
+        return JSON.stringify({
+            image: config.image,
+            tag: config.tag,
+            command: config.command,
+            networkMode: config.networkMode,
+            resources: config.resources
+        });
+    }
     /**
      * Wait up to 30 seconds for signalk-container to finish runtime
      * detection. Returns the container manager handle, or undefined
@@ -315,11 +341,30 @@ module.exports = function (app) {
         app.setPluginStatus('Starting mayara-server container...');
         const tag = settings.mayaraVersion ?? 'latest';
         const config = buildContainerConfig(tag);
-        // signalk-container handles its own config-change detection: when
-        // ensureRunning sees a config that differs from what it created the
-        // container with, it recreates. We no longer maintain a local hash
-        // file. Tag changes specifically are handled by the update service.
+        // signalk-container's ensureRunning early-returns on a running
+        // container without diffing command/network/tag — only resource
+        // limits get a live update. So a change to mayaraArgs (or the
+        // tag, or any other field) on its own would be ignored when the
+        // container is already running. Hash the rendered config and
+        // force a remove+recreate when it differs from the last
+        // successful start. Same pattern as signalk-questdb / grafana.
+        const configHash = computeConfigHash(config);
+        const hashFile = `${app.getDataDirPath()}.container-hash`;
+        let lastHash = '';
+        try {
+            lastHash = (0, fs_1.readFileSync)(hashFile, 'utf8');
+        }
+        catch {
+            /* first run — no prior hash */
+        }
+        const state = await containers.getState(CONTAINER_NAME);
+        if (state !== 'missing' && configHash !== lastHash) {
+            app.debug('Container config changed since last start — removing for recreate');
+            app.setPluginStatus('Recreating mayara-server container (config changed)...');
+            await containers.remove(CONTAINER_NAME);
+        }
         await containers.ensureRunning(CONTAINER_NAME, config);
+        (0, fs_1.writeFileSync)(hashFile, configHash);
         // Register with the centralized update service. The service auto-
         // detects whether `tag` is a semver pin (compare via GitHub releases)
         // or a floating tag like `latest`/`main` (digest drift detection).

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Plugin } from '@signalk/server-api'
 import { Request, Response, IRouter } from 'express'
+import { readFileSync, writeFileSync } from 'fs'
 import { MayaraClient } from './mayara-client'
 import { createRadarProvider } from './radar-provider'
 import { SpokeForwarder } from './spoke-forwarder'
@@ -215,13 +216,25 @@ module.exports = function (app: MayaraServerAPI): Plugin {
           // no way to roll back to the previous state — the old container's
           // ID and config are gone. Surface a clear error so the user knows
           // they need to retry the apply rather than seeing a generic 500.
+          const newConfig = buildContainerConfig(tag)
           try {
-            await containers.ensureRunning(CONTAINER_NAME, buildContainerConfig(tag))
+            await containers.ensureRunning(CONTAINER_NAME, newConfig)
           } catch (recreateErr) {
             const msg = `Container removed but recreation failed: ${errMsg(recreateErr)}. Click Update again to retry.`
             app.setPluginError(msg)
             res.status(500).json({ error: msg })
             return
+          }
+
+          // Refresh the hash file so the next plugin restart sees
+          // matching config and doesn't trigger a redundant recreate
+          // in startManagedContainer().
+          try {
+            writeFileSync(`${app.getDataDirPath()}.container-hash`, computeConfigHash(newConfig))
+          } catch (hashErr) {
+            // Non-fatal: a stale hash will just cause one extra recreate
+            // on the next plugin restart. Log and continue.
+            app.debug(`Failed to refresh container-hash: ${errMsg(hashErr)}`)
           }
 
           // Persist the new tag to disk so a plugin restart doesn't roll
@@ -328,6 +341,20 @@ module.exports = function (app: MayaraServerAPI): Plugin {
     }
   }
 
+  // Stable JSON of every ContainerConfig field that affects the
+  // resulting `podman run` invocation. Used by both startup and the
+  // /api/update/apply route so they can never drift on what counts
+  // as a "config change".
+  function computeConfigHash(config: ContainerConfig): string {
+    return JSON.stringify({
+      image: config.image,
+      tag: config.tag,
+      command: config.command,
+      networkMode: config.networkMode,
+      resources: config.resources
+    })
+  }
+
   /**
    * Wait up to 30 seconds for signalk-container to finish runtime
    * detection. Returns the container manager handle, or undefined
@@ -362,11 +389,31 @@ module.exports = function (app: MayaraServerAPI): Plugin {
     const tag = settings.mayaraVersion ?? 'latest'
     const config = buildContainerConfig(tag)
 
-    // signalk-container handles its own config-change detection: when
-    // ensureRunning sees a config that differs from what it created the
-    // container with, it recreates. We no longer maintain a local hash
-    // file. Tag changes specifically are handled by the update service.
+    // signalk-container's ensureRunning early-returns on a running
+    // container without diffing command/network/tag — only resource
+    // limits get a live update. So a change to mayaraArgs (or the
+    // tag, or any other field) on its own would be ignored when the
+    // container is already running. Hash the rendered config and
+    // force a remove+recreate when it differs from the last
+    // successful start. Same pattern as signalk-questdb / grafana.
+    const configHash = computeConfigHash(config)
+    const hashFile = `${app.getDataDirPath()}.container-hash`
+    let lastHash = ''
+    try {
+      lastHash = readFileSync(hashFile, 'utf8')
+    } catch {
+      /* first run — no prior hash */
+    }
+
+    const state = await containers.getState(CONTAINER_NAME)
+    if (state !== 'missing' && configHash !== lastHash) {
+      app.debug('Container config changed since last start — removing for recreate')
+      app.setPluginStatus('Recreating mayara-server container (config changed)...')
+      await containers.remove(CONTAINER_NAME)
+    }
+
     await containers.ensureRunning(CONTAINER_NAME, config)
+    writeFileSync(hashFile, configHash)
 
     // Register with the centralized update service. The service auto-
     // detects whether `tag` is a semver pin (compare via GitHub releases)

--- a/src/index.ts
+++ b/src/index.ts
@@ -351,6 +351,7 @@ module.exports = function (app: MayaraServerAPI): Plugin {
       tag: config.tag,
       command: config.command,
       networkMode: config.networkMode,
+      restart: config.restart,
       resources: config.resources
     })
   }
@@ -413,7 +414,16 @@ module.exports = function (app: MayaraServerAPI): Plugin {
     }
 
     await containers.ensureRunning(CONTAINER_NAME, config)
-    writeFileSync(hashFile, configHash)
+    try {
+      writeFileSync(hashFile, configHash)
+    } catch (hashErr) {
+      // Non-fatal: a failed hash write just means the next plugin
+      // restart will recompute drift and recreate the container
+      // even though nothing actually changed. Log and continue so a
+      // disk-full / read-only-fs condition doesn't take down the
+      // whole plugin start.
+      app.debug(`Failed to persist container-hash: ${errMsg(hashErr)}`)
+    }
 
     // Register with the centralized update service. The service auto-
     // detects whether `tag` is a semver pin (compare via GitHub releases)

--- a/test/container-integration.test.ts
+++ b/test/container-integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { readFileSync } from 'fs'
+import { existsSync, readFileSync, unlinkSync } from 'fs'
 import { join } from 'path'
 import type {
   ContainerConfig,
@@ -303,15 +303,24 @@ async function loadPlugin(initialConfig: Record<string, unknown> = {}): Promise<
 // Tests
 // =============================================================================
 
+// Mirrors `${app.getDataDirPath()}.container-hash` — see `makeMockApp`
+// (data dir = '/tmp/mayara-test', so hash file is its sibling in /tmp).
+const TEST_HASH_FILE = '/tmp/mayara-test.container-hash'
+
 beforeEach(() => {
   // Wipe the global between tests so they're isolated.
   delete (globalThis as { __signalk_containerManager?: unknown }).__signalk_containerManager
+  // The container-hash file is keyed off getDataDirPath(); leaving a
+  // stale one between tests would make the "did config change since
+  // last start" check non-deterministic across test ordering.
+  if (existsSync(TEST_HASH_FILE)) unlinkSync(TEST_HASH_FILE)
 })
 
 afterEach(() => {
   // Each test calls plugin.stop() explicitly; this is a safety net to
   // make sure the global doesn't leak across tests.
   delete (globalThis as { __signalk_containerManager?: unknown }).__signalk_containerManager
+  if (existsSync(TEST_HASH_FILE)) unlinkSync(TEST_HASH_FILE)
 })
 
 describe('mayara-server-signalk-plugin container integration', () => {
@@ -391,6 +400,109 @@ describe('mayara-server-signalk-plugin container integration', () => {
       expect(config.command?.filter((a) => a === '-n').length).toBe(1)
       expect(config.command).toContain('tcp:0.0.0.0:9999')
       await plugin.stop()
+    })
+  })
+
+  describe('hash-based recreation on config change', () => {
+    // Regression: v0.5.3 (commit 9cad988) removed the hash-file
+    // recreation pattern under the assumption that signalk-container
+    // diffs ContainerConfig in ensureRunning. It does not — only
+    // resource limits get a live update; command/network/tag changes
+    // on an already-running container are silently ignored. This left
+    // mayaraArgs edits in the UI doing nothing on hosts where the
+    // container had already been created (reported by Marcel,
+    // openplotter Pi).
+
+    it('writes the hash file on first successful start', async () => {
+      const { plugin } = await loadPlugin({ mayaraArgs: ['--brand', 'furuno'] })
+      expect(existsSync(TEST_HASH_FILE)).toBe(true)
+      const written = readFileSync(TEST_HASH_FILE, 'utf8')
+      expect(written).toContain('"command"')
+      expect(written).toContain('furuno')
+      await plugin.stop()
+    })
+
+    it('does NOT call remove on a restart with unchanged config', async () => {
+      // First start: container is "running" per the mock and there's
+      // no prior hash, so the conservative path is to recreate. After
+      // stop(), the hash file remains. Second start with identical
+      // config should compare equal and skip the remove.
+      const first = await loadPlugin({ mayaraArgs: ['--brand', 'furuno'] })
+      await first.plugin.stop()
+
+      const second = await loadPlugin({ mayaraArgs: ['--brand', 'furuno'] })
+      expect(second.containers._calls.remove).toEqual([])
+      await second.plugin.stop()
+    })
+
+    it('calls remove on a restart when mayaraArgs changed', async () => {
+      const first = await loadPlugin({ mayaraArgs: ['--brand', 'furuno'] })
+      await first.plugin.stop()
+
+      const second = await loadPlugin({ mayaraArgs: ['--brand', 'navico'] })
+      expect(second.containers._calls.remove).toEqual(['mayara-server'])
+      // Recreate uses the new args.
+      const { config } = second.containers._calls.ensureRunning[0]
+      expect(config.command).toContain('navico')
+      await second.plugin.stop()
+    })
+
+    it('calls remove on a restart when mayaraVersion (tag) changed', async () => {
+      const first = await loadPlugin({ mayaraVersion: 'v3.5.0' })
+      await first.plugin.stop()
+
+      const second = await loadPlugin({ mayaraVersion: 'v3.5.1' })
+      expect(second.containers._calls.remove).toEqual(['mayara-server'])
+      await second.plugin.stop()
+    })
+
+    it('does NOT call remove when getState reports missing', async () => {
+      // Fresh install — there's no container to remove and no hash.
+      // The conservative recreate path must not fire on missing.
+      const containers = makeMockContainerManager()
+      containers.getState = vi.fn(() => Promise.resolve('missing' as const))
+      globalThis.__signalk_containerManager = containers
+      const app = makeMockApp()
+      vi.resetModules()
+      const mod = (await import('../src/index')) as unknown as {
+        default: (a: unknown) => LoadedPlugin['plugin']
+      }
+      const plugin = mod.default(app)
+      plugin.registerWithRouter(makeRouter())
+      plugin.start({
+        managedContainer: true,
+        mayaraVersion: 'latest',
+        mayaraArgs: ['--brand', 'furuno']
+      })
+      await new Promise<void>((resolve) => setTimeout(resolve, 50))
+
+      expect(containers._calls.remove).toEqual([])
+      expect(containers._calls.ensureRunning.length).toBe(1)
+      // Hash is still written so a later restart with unchanged config
+      // doesn't trigger an unnecessary recreate.
+      expect(existsSync(TEST_HASH_FILE)).toBe(true)
+      await plugin.stop()
+    })
+
+    it('refreshes the hash after /api/update/apply so the next start does not double-recreate', async () => {
+      const { router, plugin } = await loadPlugin({ mayaraVersion: 'v3.5.0' })
+      const handler = getHandler(router, 'POST /api/update/apply')
+      const hashBefore = readFileSync(TEST_HASH_FILE, 'utf8')
+
+      const res = makeRes()
+      await handler({ body: { tag: 'v3.5.1' } }, res)
+      expect(res.statusCode).toBe(200)
+
+      const hashAfter = readFileSync(TEST_HASH_FILE, 'utf8')
+      expect(hashAfter).not.toEqual(hashBefore)
+      expect(hashAfter).toContain('"tag":"v3.5.1"')
+      await plugin.stop()
+
+      // Simulate plugin restart at the new tag — must NOT trigger
+      // another remove, because the hash already matches.
+      const restart = await loadPlugin({ mayaraVersion: 'v3.5.1' })
+      expect(restart.containers._calls.remove).toEqual([])
+      await restart.plugin.stop()
     })
   })
 


### PR DESCRIPTION
## Summary

- Mayara v0.5.3 (commit 9cad988) removed the local container-hash file under the assumption that signalk-container's `ensureRunning` would detect ContainerConfig drift and recreate. It does not — only resource limits get a live update; changes to `command`, `tag`, `networkMode`, etc. on an already-running container are silently ignored.
- Result: a user setting `--brand furuno --allow-wifi` in the Arguments field saved the config to disk and rebuilt the in-memory `ContainerConfig`, but the running `sk-mayara-server` kept its previous (empty-args) command line. `ps -ef | grep mayara` showed only the auto-injected `-n tcp:127.0.0.1:8375`.
- Restore the hash-based recreation pattern still used by signalk-questdb / signalk-grafana and documented in signalk-container's plugin-developer-guide. Hash is computed from a stable JSON projection of every ContainerConfig field that affects `podman run` (image, tag, command, networkMode, resources). Both startup and `/api/update/apply` write the hash so a no-op restart doesn't trigger a redundant recreate.

## Tested

- `npm run build:all` clean (lint + tsc + webpack + vitest), 46/46 tests pass — including 6 new regression tests covering: first-start writes hash, no-op restart, recreate on changed args, recreate on changed tag, no recreate when state=missing, hash refresh after `/api/update/apply`.
- `cr review --plain`: no findings.
- Manual end-to-end repro against a live Furuno radar (2× DRS-4DL+) on port 4100 / `~/.signalk-charts-docker`:
  - First start (state=missing): container created with `["mayara-server","-n","tcp:127.0.0.1:8375"]`, hash written in new 5-field format.
  - Saved `mayaraArgs: ["--brand", "furuno", "--allow-wifi"]` via plugin config API: container recreated 38s later with `["mayara-server","-n","tcp:127.0.0.1:8375","--brand","furuno","--allow-wifi"]`.
  - Saved identical config again: container `Created` timestamp unchanged, no spurious recreate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Persisted a stable container-configuration hash to disk to reliably detect config changes and trigger container recreation when needed
  * Ensures updates applied via the update endpoint refresh the stored hash so restarts don't force unnecessary recreates
  * Handles missing containers without attempting unnecessary removals

* **Tests**
  * Added integration tests covering hash persistence, restart behavior, and config-change recreation scenarios

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server-signalk-plugin/pull/22)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->