### PR TITLE
chore(release): 0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "signalk-plugin-enabled-by-default": true,


### PR DESCRIPTION
## Summary

- Patch release. Ships #22 (`fix(container): recreate when ContainerConfig changes`), which restores the hash-based recreate pattern that v0.5.3 dropped. Without it, edits to `mayaraArgs` saved correctly to disk but the running `sk-mayara-server` container kept its previous command line — a real user-reported bug.

## Tested

- `npm run build:all` clean (lint + tsc + webpack + vitest), 46/46 tests pass.
- Manual end-to-end against a live Furuno radar in #22: arg edit recreated the container with the new args; identical-config restart did not.