### PR TITLE
chore(release): 0.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "signalk-plugin-enabled-by-default": true,


### PR DESCRIPTION
## Summary

- Patch release. Ships #24 (`test: use os.tmpdir() so Windows CI passes`), restoring green CI on the Windows matrix entries that broke after #22 hard-coded `/tmp` paths in the new container-integration tests.
- No production code change since 0.6.1; users on Linux/macOS can stay on 0.6.1 without missing anything.

## Tested

- `npm run build:all` clean (lint + tsc + webpack + vitest), 46/46 tests pass on Linux. Windows fix verified in #24's PR CI.