### PR TITLE
feat(container): adopt signalk-container 1.6.0 — drop hash file, use whenReady()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,12 @@ When the plugin is auto-enabled (`signalk-plugin-enabled-by-default: true`), `st
 
 The signalk-container plugin exposes its API on `globalThis.__signalk_containerManager`, not on the `app` object. Signal K passes each plugin a shallow copy of `app`, so properties added to it are not visible across plugins. `getContainerManager()` in `src/index.ts` is the typed accessor; always handle the `undefined` case (signalk-container may not have finished its own `start()` yet, or the user may have it disabled).
 
+`waitForContainerManager()` first polls for the global to appear (signalk-container's `start()` may run after mayara's on a cold boot), then awaits `containers.whenReady()` (1.6.0+) to let runtime detection settle. After the await, re-check `getRuntime()` — `whenReady()` resolves on success OR failure of detection.
+
+### Container config-change detection is centralized
+
+signalk-container ≥1.6.0 diffs the requested `ContainerConfig` against the live container in `ensureRunning` and recreates transparently on drift across `image+tag`, `command`, `networkMode`, `env`, `volumes`, and `ports`. Resources still follow the live-update path. Mayara does **not** maintain a local `.container-hash` file — call `ensureRunning` with the same config every start and let signalk-container handle drift. A static guard in `test/container-integration.test.ts` ("src/index.ts does not import fs") catches accidental re-introduction of the old hash pattern.
+
 ### Build artifacts in `plugin/`
 
 `plugin/*.js` is in `.gitignore` but several files (`plugin/index.js`, `plugin/config/*`) are tracked from before the gitignore rule. When source changes, **rebuild and commit the corresponding `plugin/` artifact** alongside the source change so `git diff` stays honest. The `prepublishOnly` hook also rebuilds before npm publish, so the published tarball is always correct regardless.
@@ -91,7 +97,7 @@ The signalk-container plugin exposes its API on `globalThis.__signalk_containerM
 ## Dependencies
 
 - Signal K Server ≥ 2.24.0 (Radar API requirement)
-- signalk-container ≥ 0.1.6 (declared in `peerDependenciesMeta` as optional and in `signalk.requires`)
+- signalk-container ≥ 1.6.0 (declared in `peerDependenciesMeta` as optional and in `signalk.requires`)
 - Node ≥ engines floor in `package.json` (CI matrix tests Node 22 and 24)
 
 When bumping the Node engines floor, update **all** of: `package.json` engines, `package.json` `@types/node`, `.github/dependabot.yml` comment, and the README prerequisites line.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A SignalK plugin that connects to [mayara-server](https://github.com/MarineYacht
 
 - **SignalK Server ≥ 2.24.0** (the Radar API ships in 2.24.0+)
 - **Node.js ≥ 22** (tested on Node 22 and 24)
-- **[signalk-container](https://github.com/dirkwa/signalk-container) ≥ 0.1.6** (for managed container mode, optional)
+- **[signalk-container](https://github.com/dirkwa/signalk-container) ≥ 1.6.0** (for managed container mode, optional)
 - **Podman** or **Docker** runtime (for managed container mode)
 
 ## How It Works

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "ws": "^8.14.0"
   },
   "peerDependencies": {
-    "signalk-container": ">=0.1.6"
+    "signalk-container": ">=1.6.0"
   },
   "peerDependenciesMeta": {
     "signalk-container": {

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,6 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const fs_1 = require("fs");
 const mayara_client_1 = require("./mayara-client");
 const radar_provider_1 = require("./radar-provider");
 const spoke_forwarder_1 = require("./spoke-forwarder");
@@ -192,26 +191,14 @@ module.exports = function (app) {
                     // no way to roll back to the previous state — the old container's
                     // ID and config are gone. Surface a clear error so the user knows
                     // they need to retry the apply rather than seeing a generic 500.
-                    const newConfig = buildContainerConfig(tag);
                     try {
-                        await containers.ensureRunning(CONTAINER_NAME, newConfig);
+                        await containers.ensureRunning(CONTAINER_NAME, buildContainerConfig(tag));
                     }
                     catch (recreateErr) {
                         const msg = `Container removed but recreation failed: ${errMsg(recreateErr)}. Click Update again to retry.`;
                         app.setPluginError(msg);
                         res.status(500).json({ error: msg });
                         return;
-                    }
-                    // Refresh the hash file so the next plugin restart sees
-                    // matching config and doesn't trigger a redundant recreate
-                    // in startManagedContainer().
-                    try {
-                        (0, fs_1.writeFileSync)(`${app.getDataDirPath()}.container-hash`, computeConfigHash(newConfig));
-                    }
-                    catch (hashErr) {
-                        // Non-fatal: a stale hash will just cause one extra recreate
-                        // on the next plugin restart. Log and continue.
-                        app.debug(`Failed to refresh container-hash: ${errMsg(hashErr)}`);
                     }
                     // Persist the new tag to disk so a plugin restart doesn't roll
                     // back to the previous version. We update the in-memory copy
@@ -301,36 +288,35 @@ module.exports = function (app) {
             resources: DEFAULT_RESOURCES
         };
     }
-    // Stable JSON of every ContainerConfig field that affects the
-    // resulting `podman run` invocation. Used by both startup and the
-    // /api/update/apply route so they can never drift on what counts
-    // as a "config change".
-    function computeConfigHash(config) {
-        return JSON.stringify({
-            image: config.image,
-            tag: config.tag,
-            command: config.command,
-            networkMode: config.networkMode,
-            restart: config.restart,
-            resources: config.resources
-        });
-    }
     /**
-     * Wait up to 30 seconds for signalk-container to finish runtime
-     * detection. Returns the container manager handle, or undefined
-     * if it never became ready (in which case the caller should set
-     * a plugin error).
+     * Wait up to `timeoutMs` for signalk-container to be both loaded
+     * (cross-plugin global populated) and finished with runtime detection.
+     * Returns the container manager handle, or undefined if either phase
+     * timed out or detection failed. Caller sets a plugin error on
+     * undefined.
      */
     async function waitForContainerManager(timeoutMs = 30000) {
         const deadline = Date.now() + timeoutMs;
-        while (Date.now() < deadline) {
-            const containers = getContainerManager();
-            if (containers?.getRuntime())
-                return containers;
-            app.setPluginStatus('Waiting for container runtime detection...');
-            await new Promise((resolve) => setTimeout(resolve, 1000));
+        // Phase 1: poll for the cross-plugin global. signalk-container's
+        // start() may not have run yet on a fresh SK boot.
+        let containers = getContainerManager();
+        while (!containers && Date.now() < deadline) {
+            app.setPluginStatus('Waiting for signalk-container plugin to load...');
+            await new Promise((resolve) => setTimeout(resolve, 500));
+            containers = getContainerManager();
         }
-        return undefined;
+        if (!containers)
+            return undefined;
+        // Phase 2: await whenReady() with a remaining-time cap. whenReady()
+        // resolves on success OR failure of runtime detection, so re-check
+        // getRuntime() afterwards.
+        app.setPluginStatus('Waiting for container runtime detection...');
+        const remaining = Math.max(0, deadline - Date.now());
+        await Promise.race([
+            containers.whenReady(),
+            new Promise((resolve) => setTimeout(resolve, remaining))
+        ]);
+        return containers.getRuntime() ? containers : undefined;
     }
     async function startManagedContainer(settings) {
         const containers = await waitForContainerManager();
@@ -342,40 +328,12 @@ module.exports = function (app) {
         app.setPluginStatus('Starting mayara-server container...');
         const tag = settings.mayaraVersion ?? 'latest';
         const config = buildContainerConfig(tag);
-        // signalk-container's ensureRunning early-returns on a running
-        // container without diffing command/network/tag — only resource
-        // limits get a live update. So a change to mayaraArgs (or the
-        // tag, or any other field) on its own would be ignored when the
-        // container is already running. Hash the rendered config and
-        // force a remove+recreate when it differs from the last
-        // successful start. Same pattern as signalk-questdb / grafana.
-        const configHash = computeConfigHash(config);
-        const hashFile = `${app.getDataDirPath()}.container-hash`;
-        let lastHash = '';
-        try {
-            lastHash = (0, fs_1.readFileSync)(hashFile, 'utf8');
-        }
-        catch {
-            /* first run — no prior hash */
-        }
-        const state = await containers.getState(CONTAINER_NAME);
-        if (state !== 'missing' && configHash !== lastHash) {
-            app.debug('Container config changed since last start — removing for recreate');
-            app.setPluginStatus('Recreating mayara-server container (config changed)...');
-            await containers.remove(CONTAINER_NAME);
-        }
+        // signalk-container ≥1.6.0 diffs ContainerConfig against the live
+        // container on every ensureRunning call and recreates transparently
+        // on drift across image+tag, command, networkMode, env, volumes,
+        // and ports. Resources follow the live-update path. No local hash
+        // tracking needed.
         await containers.ensureRunning(CONTAINER_NAME, config);
-        try {
-            (0, fs_1.writeFileSync)(hashFile, configHash);
-        }
-        catch (hashErr) {
-            // Non-fatal: a failed hash write just means the next plugin
-            // restart will recompute drift and recreate the container
-            // even though nothing actually changed. Log and continue so a
-            // disk-full / read-only-fs condition doesn't take down the
-            // whole plugin start.
-            app.debug(`Failed to persist container-hash: ${errMsg(hashErr)}`);
-        }
         // Register with the centralized update service. The service auto-
         // detects whether `tag` is a semver pin (compare via GitHub releases)
         // or a floating tag like `latest`/`main` (digest drift detection).

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import { Plugin } from '@signalk/server-api'
 import { Request, Response, IRouter } from 'express'
-import { readFileSync, writeFileSync } from 'fs'
 import { MayaraClient } from './mayara-client'
 import { createRadarProvider } from './radar-provider'
 import { SpokeForwarder } from './spoke-forwarder'
@@ -216,25 +215,13 @@ module.exports = function (app: MayaraServerAPI): Plugin {
           // no way to roll back to the previous state — the old container's
           // ID and config are gone. Surface a clear error so the user knows
           // they need to retry the apply rather than seeing a generic 500.
-          const newConfig = buildContainerConfig(tag)
           try {
-            await containers.ensureRunning(CONTAINER_NAME, newConfig)
+            await containers.ensureRunning(CONTAINER_NAME, buildContainerConfig(tag))
           } catch (recreateErr) {
             const msg = `Container removed but recreation failed: ${errMsg(recreateErr)}. Click Update again to retry.`
             app.setPluginError(msg)
             res.status(500).json({ error: msg })
             return
-          }
-
-          // Refresh the hash file so the next plugin restart sees
-          // matching config and doesn't trigger a redundant recreate
-          // in startManagedContainer().
-          try {
-            writeFileSync(`${app.getDataDirPath()}.container-hash`, computeConfigHash(newConfig))
-          } catch (hashErr) {
-            // Non-fatal: a stale hash will just cause one extra recreate
-            // on the next plugin restart. Log and continue.
-            app.debug(`Failed to refresh container-hash: ${errMsg(hashErr)}`)
           }
 
           // Persist the new tag to disk so a plugin restart doesn't roll
@@ -341,38 +328,38 @@ module.exports = function (app: MayaraServerAPI): Plugin {
     }
   }
 
-  // Stable JSON of every ContainerConfig field that affects the
-  // resulting `podman run` invocation. Used by both startup and the
-  // /api/update/apply route so they can never drift on what counts
-  // as a "config change".
-  function computeConfigHash(config: ContainerConfig): string {
-    return JSON.stringify({
-      image: config.image,
-      tag: config.tag,
-      command: config.command,
-      networkMode: config.networkMode,
-      restart: config.restart,
-      resources: config.resources
-    })
-  }
-
   /**
-   * Wait up to 30 seconds for signalk-container to finish runtime
-   * detection. Returns the container manager handle, or undefined
-   * if it never became ready (in which case the caller should set
-   * a plugin error).
+   * Wait up to `timeoutMs` for signalk-container to be both loaded
+   * (cross-plugin global populated) and finished with runtime detection.
+   * Returns the container manager handle, or undefined if either phase
+   * timed out or detection failed. Caller sets a plugin error on
+   * undefined.
    */
   async function waitForContainerManager(
     timeoutMs = 30000
   ): Promise<ContainerManagerApi | undefined> {
     const deadline = Date.now() + timeoutMs
-    while (Date.now() < deadline) {
-      const containers = getContainerManager()
-      if (containers?.getRuntime()) return containers
-      app.setPluginStatus('Waiting for container runtime detection...')
-      await new Promise<void>((resolve) => setTimeout(resolve, 1000))
+
+    // Phase 1: poll for the cross-plugin global. signalk-container's
+    // start() may not have run yet on a fresh SK boot.
+    let containers = getContainerManager()
+    while (!containers && Date.now() < deadline) {
+      app.setPluginStatus('Waiting for signalk-container plugin to load...')
+      await new Promise<void>((resolve) => setTimeout(resolve, 500))
+      containers = getContainerManager()
     }
-    return undefined
+    if (!containers) return undefined
+
+    // Phase 2: await whenReady() with a remaining-time cap. whenReady()
+    // resolves on success OR failure of runtime detection, so re-check
+    // getRuntime() afterwards.
+    app.setPluginStatus('Waiting for container runtime detection...')
+    const remaining = Math.max(0, deadline - Date.now())
+    await Promise.race([
+      containers.whenReady(),
+      new Promise<void>((resolve) => setTimeout(resolve, remaining))
+    ])
+    return containers.getRuntime() ? containers : undefined
   }
 
   async function startManagedContainer(settings: Partial<Config>): Promise<void> {
@@ -390,40 +377,12 @@ module.exports = function (app: MayaraServerAPI): Plugin {
     const tag = settings.mayaraVersion ?? 'latest'
     const config = buildContainerConfig(tag)
 
-    // signalk-container's ensureRunning early-returns on a running
-    // container without diffing command/network/tag — only resource
-    // limits get a live update. So a change to mayaraArgs (or the
-    // tag, or any other field) on its own would be ignored when the
-    // container is already running. Hash the rendered config and
-    // force a remove+recreate when it differs from the last
-    // successful start. Same pattern as signalk-questdb / grafana.
-    const configHash = computeConfigHash(config)
-    const hashFile = `${app.getDataDirPath()}.container-hash`
-    let lastHash = ''
-    try {
-      lastHash = readFileSync(hashFile, 'utf8')
-    } catch {
-      /* first run — no prior hash */
-    }
-
-    const state = await containers.getState(CONTAINER_NAME)
-    if (state !== 'missing' && configHash !== lastHash) {
-      app.debug('Container config changed since last start — removing for recreate')
-      app.setPluginStatus('Recreating mayara-server container (config changed)...')
-      await containers.remove(CONTAINER_NAME)
-    }
-
+    // signalk-container ≥1.6.0 diffs ContainerConfig against the live
+    // container on every ensureRunning call and recreates transparently
+    // on drift across image+tag, command, networkMode, env, volumes,
+    // and ports. Resources follow the live-update path. No local hash
+    // tracking needed.
     await containers.ensureRunning(CONTAINER_NAME, config)
-    try {
-      writeFileSync(hashFile, configHash)
-    } catch (hashErr) {
-      // Non-fatal: a failed hash write just means the next plugin
-      // restart will recompute drift and recreate the container
-      // even though nothing actually changed. Log and continue so a
-      // disk-full / read-only-fs condition doesn't take down the
-      // whole plugin start.
-      app.debug(`Failed to persist container-hash: ${errMsg(hashErr)}`)
-    }
 
     // Register with the centralized update service. The service auto-
     // detects whether `tag` is a semver pin (compare via GitHub releases)

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export interface MayaraServerAPI extends ServerAPI {
 }
 
 // =============================================================================
-// signalk-container v0.1.6 API mirror
+// signalk-container v1.6.0 API mirror
 // =============================================================================
 //
 // These types are intentionally hand-rolled rather than imported from the
@@ -24,7 +24,7 @@ export interface MayaraServerAPI extends ServerAPI {
 // When signalk-container's API changes, mirror the relevant subset here. Only
 // the methods mayara actually uses need to be declared.
 //
-// Last synced against signalk-container: v0.1.6
+// Last synced against signalk-container: v1.6.0
 
 export type ContainerState = 'running' | 'stopped' | 'missing' | 'no-runtime'
 
@@ -132,6 +132,13 @@ export interface UpdateServiceApi {
 
 export interface ContainerManagerApi {
   getRuntime: () => ContainerRuntimeInfo | null
+  /**
+   * Resolves once runtime detection has settled (success OR failure).
+   * `getRuntime()` is guaranteed non-null only when this resolves AND
+   * detection succeeded — callers should re-check after the await.
+   * Available in signalk-container 1.6.0+.
+   */
+  whenReady: () => Promise<void>
   pullImage: (image: string, onProgress?: (msg: string) => void) => Promise<void>
   imageExists: (image: string) => Promise<boolean>
   getImageDigest: (imageOrContainer: string) => Promise<string | null>

--- a/test/container-integration.test.ts
+++ b/test/container-integration.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { existsSync, readFileSync, unlinkSync } from 'fs'
-import { tmpdir } from 'os'
+import { readFileSync } from 'fs'
 import { join } from 'path'
 import type {
   ContainerConfig,
@@ -94,6 +93,7 @@ function makeMockContainerManager(): MockContainerManager {
       version: '5.0.0',
       isPodmanDockerShim: false
     }),
+    whenReady: vi.fn(() => Promise.resolve()),
     pullImage: vi.fn((image: string) => {
       calls.pullImage.push(image)
       return Promise.resolve()
@@ -162,21 +162,15 @@ interface MockApp {
   binaryStreamManager: undefined
 }
 
-// Real per-OS tmp path — Windows runners don't have a /tmp directory,
-// so writeFileSync against /tmp/mayara-test.container-hash fails with
-// ENOENT. tmpdir() returns C:\Users\…\AppData\Local\Temp on Windows
-// and /tmp on Linux/macOS. Both the mock app and TEST_HASH_FILE
-// derive from this single constant so they cannot drift.
-const TEST_DATA_DIR = join(tmpdir(), 'mayara-test')
-const TEST_HASH_FILE = `${TEST_DATA_DIR}.container-hash`
-
 function makeMockApp(): MockApp {
   return {
     debug: vi.fn(),
     error: vi.fn(),
     setPluginStatus: vi.fn(),
     setPluginError: vi.fn(),
-    getDataDirPath: () => TEST_DATA_DIR,
+    // Opaque string — mayara no longer reads or writes anything in
+    // getDataDirPath() now that the hash-file workaround is gone.
+    getDataDirPath: () => '/tmp/mayara-test',
     // SignalK persistence API: writes to plugin-config-data/<pluginId>.json
     // The signature is (config, callback) where callback gets a NodeJS.ErrnoException | null.
     savePluginOptions: vi.fn(
@@ -315,17 +309,12 @@ async function loadPlugin(initialConfig: Record<string, unknown> = {}): Promise<
 beforeEach(() => {
   // Wipe the global between tests so they're isolated.
   delete (globalThis as { __signalk_containerManager?: unknown }).__signalk_containerManager
-  // The container-hash file is keyed off getDataDirPath(); leaving a
-  // stale one between tests would make the "did config change since
-  // last start" check non-deterministic across test ordering.
-  if (existsSync(TEST_HASH_FILE)) unlinkSync(TEST_HASH_FILE)
 })
 
 afterEach(() => {
   // Each test calls plugin.stop() explicitly; this is a safety net to
   // make sure the global doesn't leak across tests.
   delete (globalThis as { __signalk_containerManager?: unknown }).__signalk_containerManager
-  if (existsSync(TEST_HASH_FILE)) unlinkSync(TEST_HASH_FILE)
 })
 
 describe('mayara-server-signalk-plugin container integration', () => {
@@ -406,108 +395,24 @@ describe('mayara-server-signalk-plugin container integration', () => {
       expect(config.command).toContain('tcp:0.0.0.0:9999')
       await plugin.stop()
     })
-  })
 
-  describe('hash-based recreation on config change', () => {
-    // Regression: v0.5.3 (commit 9cad988) removed the hash-file
-    // recreation pattern under the assumption that signalk-container
-    // diffs ContainerConfig in ensureRunning. It does not — only
-    // resource limits get a live update; command/network/tag changes
-    // on an already-running container are silently ignored. This left
-    // mayaraArgs edits in the UI doing nothing on hosts where the
-    // container had already been created (reported by Marcel,
-    // openplotter Pi).
-
-    it('writes the hash file on first successful start', async () => {
-      const { plugin } = await loadPlugin({ mayaraArgs: ['--brand', 'furuno'] })
-      expect(existsSync(TEST_HASH_FILE)).toBe(true)
-      const written = readFileSync(TEST_HASH_FILE, 'utf8')
-      expect(written).toContain('"command"')
-      expect(written).toContain('furuno')
+    it('awaits containers.whenReady() before calling ensureRunning', async () => {
+      // signalk-container 1.6.0 exposes whenReady() as the canonical
+      // "wait for runtime detection to settle" signal. Mayara must
+      // await it before any other container API call, otherwise
+      // ensureRunning would race against runtime probing on a cold
+      // SK boot. Use vitest's invocationCallOrder to assert
+      // whenReady was invoked strictly before ensureRunning.
+      const { containers, plugin } = await loadPlugin()
+      expect(containers.whenReady).toHaveBeenCalledTimes(1)
+      const whenReadyOrder = (
+        containers.whenReady as unknown as { mock: { invocationCallOrder: number[] } }
+      ).mock.invocationCallOrder[0]
+      const ensureRunningOrder = (
+        containers.ensureRunning as unknown as { mock: { invocationCallOrder: number[] } }
+      ).mock.invocationCallOrder[0]
+      expect(whenReadyOrder).toBeLessThan(ensureRunningOrder)
       await plugin.stop()
-    })
-
-    it('does NOT call remove on a restart with unchanged config', async () => {
-      // First start: container is "running" per the mock and there's
-      // no prior hash, so the conservative path is to recreate. After
-      // stop(), the hash file remains. Second start with identical
-      // config should compare equal and skip the remove.
-      const first = await loadPlugin({ mayaraArgs: ['--brand', 'furuno'] })
-      await first.plugin.stop()
-
-      const second = await loadPlugin({ mayaraArgs: ['--brand', 'furuno'] })
-      expect(second.containers._calls.remove).toEqual([])
-      await second.plugin.stop()
-    })
-
-    it('calls remove on a restart when mayaraArgs changed', async () => {
-      const first = await loadPlugin({ mayaraArgs: ['--brand', 'furuno'] })
-      await first.plugin.stop()
-
-      const second = await loadPlugin({ mayaraArgs: ['--brand', 'navico'] })
-      expect(second.containers._calls.remove).toEqual(['mayara-server'])
-      // Recreate uses the new args.
-      const { config } = second.containers._calls.ensureRunning[0]
-      expect(config.command).toContain('navico')
-      await second.plugin.stop()
-    })
-
-    it('calls remove on a restart when mayaraVersion (tag) changed', async () => {
-      const first = await loadPlugin({ mayaraVersion: 'v3.5.0' })
-      await first.plugin.stop()
-
-      const second = await loadPlugin({ mayaraVersion: 'v3.5.1' })
-      expect(second.containers._calls.remove).toEqual(['mayara-server'])
-      await second.plugin.stop()
-    })
-
-    it('does NOT call remove when getState reports missing', async () => {
-      // Fresh install — there's no container to remove and no hash.
-      // The conservative recreate path must not fire on missing.
-      const containers = makeMockContainerManager()
-      containers.getState = vi.fn(() => Promise.resolve('missing' as const))
-      globalThis.__signalk_containerManager = containers
-      const app = makeMockApp()
-      vi.resetModules()
-      const mod = (await import('../src/index')) as unknown as {
-        default: (a: unknown) => LoadedPlugin['plugin']
-      }
-      const plugin = mod.default(app)
-      plugin.registerWithRouter(makeRouter())
-      plugin.start({
-        managedContainer: true,
-        mayaraVersion: 'latest',
-        mayaraArgs: ['--brand', 'furuno']
-      })
-      await new Promise<void>((resolve) => setTimeout(resolve, 50))
-
-      expect(containers._calls.remove).toEqual([])
-      expect(containers._calls.ensureRunning.length).toBe(1)
-      // Hash is still written so a later restart with unchanged config
-      // doesn't trigger an unnecessary recreate.
-      expect(existsSync(TEST_HASH_FILE)).toBe(true)
-      await plugin.stop()
-    })
-
-    it('refreshes the hash after /api/update/apply so the next start does not double-recreate', async () => {
-      const { router, plugin } = await loadPlugin({ mayaraVersion: 'v3.5.0' })
-      const handler = getHandler(router, 'POST /api/update/apply')
-      const hashBefore = readFileSync(TEST_HASH_FILE, 'utf8')
-
-      const res = makeRes()
-      await handler({ body: { tag: 'v3.5.1' } }, res)
-      expect(res.statusCode).toBe(200)
-
-      const hashAfter = readFileSync(TEST_HASH_FILE, 'utf8')
-      expect(hashAfter).not.toEqual(hashBefore)
-      expect(hashAfter).toContain('"tag":"v3.5.1"')
-      await plugin.stop()
-
-      // Simulate plugin restart at the new tag — must NOT trigger
-      // another remove, because the hash already matches.
-      const restart = await loadPlugin({ mayaraVersion: 'v3.5.1' })
-      expect(restart.containers._calls.remove).toEqual([])
-      await restart.plugin.stop()
     })
   })
 
@@ -709,5 +614,14 @@ describe('no shellout regression', () => {
   it('src/index.ts does not import util.promisify (used to wrap exec)', () => {
     const source = readFileSync(join(__dirname, '../src/index.ts'), 'utf-8')
     expect(source).not.toMatch(/promisify/)
+  })
+
+  it('src/index.ts does not import fs (hash-file pattern is obsolete)', () => {
+    // signalk-container ≥1.6.0 handles ContainerConfig drift centrally.
+    // Re-introducing fs imports here is almost always a sign someone
+    // is about to add another local hash file or sidecar marker.
+    const source = readFileSync(join(__dirname, '../src/index.ts'), 'utf-8')
+    expect(source).not.toMatch(/from\s+['"]fs['"]/)
+    expect(source).not.toMatch(/require\s*\(\s*['"]fs['"]/)
   })
 })


### PR DESCRIPTION
## Summary

- signalk-container 1.6.0 (now on npm `latest`) centralizes the `ContainerConfig` drift detection that mayara was working around locally in #22. `ensureRunning` now diffs against the live container and recreates transparently on changes to `image+tag`, `command`, `networkMode`, `env`, `volumes`, and `ports`. The `.container-hash` file becomes dead code on a 1.6.0+ host.
- Adopts `whenReady()` (also new in 1.6.0) to replace the 1Hz polling loop in `waitForContainerManager()`. Runtime status no longer chatters at 1-second cadence during a cold SK boot — single await.
- Bumps peer dep floor from `>=0.1.6` to `>=1.6.0` (with matching updates to `AGENTS.md` and `README.md` prerequisite lines).
- Adds a static guard in `test/container-integration.test.ts` asserting `src/index.ts` does not import `fs` — same pattern as the existing "no shellout regression" tests — so the hash-file workaround can't silently come back.
- Plugin source is **156 lines smaller**. VolumeSpec / `onVolumeIssue` (the third major 1.6.0 addition) is not adopted — mayara uses `networkMode: 'host'` and mounts no volumes.

## Tested

- `npm run build:all` clean (lint + tsc + webpack + vitest). 42/42 tests pass (was 46 — 6 hash-file tests removed, 1 `whenReady` ordering test + 1 `fs`-import static guard added).
- `cr review --plain`: no findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated container-mode operational guidance and deployment prerequisites.

* **Chores**
  * Updated minimum signalk-container peer dependency requirement from 0.1.6 to 1.6.0.

* **Tests**
  * Refactored container integration test suite to align with current platform behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server-signalk-plugin/pull/26)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->