### PR TITLE
chore(release): 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "0.6.2",
+  "version": "1.0.0",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "signalk-plugin-enabled-by-default": true,


### PR DESCRIPTION
## Summary

- Major bump to 1.0.0 marking the alignment with signalk-container 1.6.0. Ships #26 (`feat(container): adopt signalk-container 1.6.0 — drop hash file, use whenReady()`).
- The peer-dep floor on `signalk-container` moved from `>=0.1.6` to `>=1.6.0`, which is a breaking change for any user still on the older signalk-container. They must upgrade signalk-container alongside this release.
- All local container-drift workaround code is gone — drift detection is now signalk-container's responsibility, and `whenReady()` replaces the runtime-detection polling loop. Plugin source is **156 lines smaller** than 0.6.2.

## Tested

- `npm run build:all` clean (lint + tsc + webpack + vitest), 42/42 tests pass.
- Manual end-to-end against a live Furuno radar setup in #26: `whenReady()` adoption verified (no 1Hz polling chatter), config change triggers signalk-container 1.6.0's central diff (`Container sk-mayara-server config drift detected (command); recreating`), legacy `.container-hash` file is no longer written.