### PR TITLE
chore(deps-dev): bump typescript to 6.0.3 (with tsconfig adjustment)

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "eslint-config-prettier": "^10.0.0",
     "eslint-plugin-prettier": "^5.0.0",
     "prettier": "^3.0.0",
-    "typescript": "^5.5.0",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.0.0",
     "babel-loader": "^10.1.1",
     "react": "^19.2.4",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "commonjs",
+    "module": "node16",
     "lib": ["ES2022"],
     "outDir": "plugin",
     "rootDir": "src",
@@ -13,7 +13,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "resolveJsonModule": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node16"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "plugin", "test"]


### PR DESCRIPTION
## Summary

- Bumps `typescript` from 5.9.3 to 6.0.3 (dev dep).
- TypeScript 6 turned the previously-deprecated `moduleResolution: node` into a hard error. Migrates `tsconfig.json` to `module: node16` + `moduleResolution: node16` (the documented replacement for Node-runtime projects). No source changes needed — the codebase uses bare-name imports only, which both resolvers handle identically, and `module: node16` still emits CommonJS for files outside a `"type": "module"` package boundary.
- Replaces #21 (typescript bump alone), which on its own would not build under TS 6.

## Tested

- `npm run build:all` clean (lint + tsc + webpack + vitest), 42/42 tests pass.
- `cr review --plain`: one finding flagged that I addressed in a reply on the PR — the suggested `types: ['node']` and `noUncheckedSideEffectImports: true` are no-ops given the current build is clean, and the "separate release PR" rule applies to the plugin's own version, not dev-dep bumps.