### PR TITLE
chore: force LF line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Force LF line endings on checkout regardless of the host's
+# core.autocrlf setting. Prettier/eslint enforce LF; without this,
+# Windows CI runners check out CRLF and `prettier --check` reports
+# every line as "Delete `␍`".
+* text=auto eol=lf


### PR DESCRIPTION
## Summary
- Add `.gitattributes` with `* text=auto eol=lf` so checkouts use LF regardless of host `core.autocrlf`.
- Prevents Windows CI from checking out CRLF and failing `prettier --check` with "Delete `␍`" on every line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development configuration to ensure consistent file handling across environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server-signalk-plugin/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->