### PR TITLE
docs: explain the Signal K authentication / device-token flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The plugin uses the standard Signal K device-access-request flow to obtain one. 
 
 1. **On first start**, the plugin POSTs a `readwrite` access request for `clientId = mayara-server-signalk-plugin`. The request appears in your admin UI under **Security → Access Requests** with description _"MaYaRa Radar (Server) — AIS overlay seeding + radar/target/notification writebacks"_.
 2. Plugin status changes to _"Awaiting Signal K token approval — see Security → Access Requests"_. Approve the request once. (Mayara may also push radar targets, MARPA tracks, and notifications back to Signal K in future releases — hence the `readwrite` scope.)
-3. The plugin caches the issued JWT to `${dataDir}/plugin-config-data/mayara-server-signalk-plugin/signalk-token` (mode `0600`) and recreates the container with `-n ws:127.0.0.1:${PORT}` plus `--signalk-token-file /run/mayara/token`.
+3. The plugin caches the issued JWT to a `signalk-token` file in its plugin data directory (mode `0600`) — typically `~/.signalk/plugin-config-data/mayara-server-signalk-plugin/signalk-token` — and recreates the container with `-n ws:127.0.0.1:${PORT}` plus `--signalk-token-file /run/mayara/token`.
 4. Subsequent restarts reuse the cached token — no further admin interaction.
 
 Until the request is approved (or if you deny it), the container runs with `-n tcp:127.0.0.1:${TCPSTREAMPORT}` instead. Navigation deltas still flow, only the initial AIS REST snapshot is skipped (the overlay then fills from live deltas as vessels are heard).

--- a/README.md
+++ b/README.md
@@ -66,6 +66,36 @@ With **signalk-container** installed, the plugin automatically pulls and manages
 
 Without arguments, mayara-server auto-discovers all radar brands on all network interfaces.
 
+### Signal K Authentication
+
+The plugin reaches back into the local Signal K server in two places: it subscribes to navigation deltas over WebSocket (so the radar overlay can render own-ship heading/position), and it does a one-shot REST read of `/signalk/v1/api/vessels/` so the AIS overlay is populated immediately (rather than trickling in vessel-by-vessel over the next 5–60 s). On a Signal K server with security **enabled** — the default for fresh installs — both calls need a bearer token.
+
+The plugin uses the standard Signal K device-access-request flow to obtain one. No copy-pasting tokens from the admin UI required:
+
+1. **On first start**, the plugin POSTs a `readwrite` access request for `clientId = mayara-server-signalk-plugin`. The request appears in your admin UI under **Security → Access Requests** with description _"MaYaRa Radar (Server) — AIS overlay seeding + radar/target/notification writebacks"_.
+2. Plugin status changes to _"Awaiting Signal K token approval — see Security → Access Requests"_. Approve the request once. (Mayara may also push radar targets, MARPA tracks, and notifications back to Signal K in future releases — hence the `readwrite` scope.)
+3. The plugin caches the issued JWT to `${dataDir}/plugin-config-data/mayara-server-signalk-plugin/signalk-token` (mode `0600`) and recreates the container with `-n ws:127.0.0.1:${PORT}` plus `--signalk-token-file /run/mayara/token`.
+4. Subsequent restarts reuse the cached token — no further admin interaction.
+
+Until the request is approved (or if you deny it), the container runs with `-n tcp:127.0.0.1:${TCPSTREAMPORT}` instead. Navigation deltas still flow, only the initial AIS REST snapshot is skipped (the overlay then fills from live deltas as vessels are heard).
+
+**Settings:**
+
+- **`requestSignalkToken`** (default: `true`) — disables the auto-request flow. Set to `false` if you'd rather mayara stay on the unauthenticated TCP stream, or if you intend to pass a token manually via `mayaraArgs: ["--signalk-token", "<token>"]` (or `--signalk-token-file`).
+
+**Requirements:**
+
+- mayara-server image with the `--signalk-token-file` flag — present on `:main` and on releases newer than v3.5.1. If your `Image version` is `latest` and the most recent release is still ≤ v3.5.1, switch to `main` (or wait for the next release) to exercise the WS-with-token path. The token request itself works regardless of the mayara version.
+- Signal K's **Security → Settings → Allow New Device Registration** must remain enabled (it's on by default). If you've disabled it, the plugin's POST returns 403, the container stays on the TCP fallback, and plugin status surfaces a hint.
+
+**Revoking access:** delete the device entry in **Security → Devices** (or **Security → Access Requests** if still listed there), then delete the plugin's cached token file:
+
+```bash
+rm ~/.signalk/plugin-config-data/mayara-server-signalk-plugin/signalk-token
+```
+
+Restart the plugin and it'll request a fresh token.
+
 ### Resource Limits
 
 The plugin sets sensible default resource caps so a runaway container can't take down Signal K:


### PR DESCRIPTION
## Summary

- PR #30 added auto-request of a Signal K device token but the README didn't mention it; new users on a secured Signal K wouldn't know what the "Awaiting Signal K token approval" status meant or what to do about it.
- New **Signal K Authentication** section in the README walks through: why mayara reaches back into Signal K, the auto-request flow, the `requestSignalkToken` setting, the mayara-server `:main` requirement until the next mayara release, and how to revoke + remint.

## Tested

- Confirmed the admin-UI label is **Allow New Device Registration** (not "Allow Device Access Requests") by reading signalk-server/packages/server-admin-ui/src/views/security/Settings.tsx
- Doc-only change; no source touched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Signal K Authentication section explaining the authentication process, token caching mechanism, fallback behavior without approval, and instructions for configuring and revoking access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server-signalk-plugin/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->