### PR TITLE
fix(container): resolve token host path via signalk-container

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,5 +1,39 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
+const path = __importStar(require("path"));
 const mayara_client_1 = require("./mayara-client");
 const radar_provider_1 = require("./radar-provider");
 const spoke_forwarder_1 = require("./spoke-forwarder");
@@ -9,7 +43,12 @@ const MAYARA_IMAGE = 'ghcr.io/marineyachtradar/mayara-server';
 const CONTAINER_NAME = 'mayara-server';
 const PLUGIN_ID = 'mayara-server-signalk-plugin';
 const SAFE_TAG = /^[a-zA-Z0-9._-]+$/;
-const TOKEN_PATH_IN_CONTAINER = '/run/mayara/token';
+// Where mayara reads the token file inside its container. The plugin
+// bind-mounts its plugin-config-data directory (containing the
+// `signalk-token` file) at TOKEN_DIR_IN_CONTAINER; the file then
+// appears at TOKEN_DIR_IN_CONTAINER + the relative subpath returned
+// by `containers.resolveHostPath()`.
+const TOKEN_DIR_IN_CONTAINER = '/run/mayara';
 /**
  * Sensible default resource limits for the mayara-server container.
  * Tested on a Pi 5 8GB with a Garmin xHD2 radar at 24 NM range.
@@ -203,7 +242,7 @@ module.exports = function (app) {
                     // ID and config are gone. Surface a clear error so the user knows
                     // they need to retry the apply rather than seeing a generic 500.
                     try {
-                        await containers.ensureRunning(CONTAINER_NAME, buildContainerConfig(tag));
+                        await containers.ensureRunning(CONTAINER_NAME, await buildContainerConfig(containers, tag));
                     }
                     catch (recreateErr) {
                         const msg = `Container removed but recreation failed: ${errMsg(recreateErr)}. Click Update again to retry.`;
@@ -296,23 +335,47 @@ module.exports = function (app) {
      * Either way, `mayaraArgs` may override `-n` entirely, in which case
      * we don't inject our default or `--signalk-token-file`.
      */
-    function buildContainerConfig(tag) {
+    async function buildContainerConfig(containers, tag) {
         const userArgs = currentSettings?.mayaraArgs ?? [];
         const userOverridesNav = userArgs.some((a) => a === '-n' || a === '--navigation-address');
         const skPort = Number(process.env.PORT) || 3000;
         const tcpPort = Number(process.env.TCPSTREAMPORT) || 8375;
         const dataDir = app.getDataDirPath();
         const haveToken = (0, signalk_token_1.hasCachedToken)(dataDir);
-        const tokenFile = (0, signalk_token_1.tokenFilePath)(dataDir);
         const injected = [];
         const volumes = {};
         if (!userOverridesNav) {
             if (haveToken) {
-                injected.push('-n', `ws:127.0.0.1:${skPort}`, '--signalk-token-file', TOKEN_PATH_IN_CONTAINER);
-                // signalk-container volume shape: key = container path, value =
-                // host path. Mount the file (not a directory) so mayara only
-                // sees its token, not the whole data dir.
-                volumes[TOKEN_PATH_IN_CONTAINER] = tokenFile;
+                // Translate the in-SK absolute token path into the host-side
+                // (source, subPath) pair signalk-container's bind mount can
+                // actually reach. Critical when SK runs inside a container —
+                // `app.getDataDirPath()` returns a path inside that container,
+                // not on the host where podman/docker actually lives. On
+                // bare-metal SK the resolver returns the path unchanged.
+                const tokenAbsPath = (0, signalk_token_1.tokenFilePath)(dataDir);
+                const resolved = await containers.resolveHostPath(tokenAbsPath);
+                if (resolved !== null) {
+                    // Mount the resolved source (typically the plugin's own
+                    // data dir, since SK gives each plugin a private subtree)
+                    // and tell mayara where to find the token file inside it.
+                    // `subPath` is relative to `source`; when source already
+                    // equals tokenAbsPath, subPath is "" (file mount).
+                    const tokenPathInContainer = path.posix.join(TOKEN_DIR_IN_CONTAINER, resolved.subPath);
+                    injected.push('-n', `ws:127.0.0.1:${skPort}`, '--signalk-token-file', tokenPathInContainer);
+                    volumes[TOKEN_DIR_IN_CONTAINER] = resolved.source;
+                }
+                else {
+                    // SK is containerized and no host mount covers the token
+                    // path. Fall back to TCP rather than fail startup; surface
+                    // the gap so the operator knows AIS REST seeding won't
+                    // happen until they fix the mount.
+                    app.setPluginError('Signal K token cached but the data directory is not bind-mounted ' +
+                        'from the host — managed mayara container cannot read it. ' +
+                        'Falling back to anonymous TCP transport (AIS overlay fills ' +
+                        'from live deltas only). Bind-mount your SK data directory ' +
+                        'into the SK container to enable WS+token mode.');
+                    injected.push('-n', `tcp:127.0.0.1:${tcpPort}`);
+                }
             }
             else {
                 injected.push('-n', `tcp:127.0.0.1:${tcpPort}`);
@@ -382,7 +445,7 @@ module.exports = function (app) {
             case 'cached':
                 // Race: token landed between the readCachedToken above and the
                 // POST. Recreate to pick up WS transport.
-                await containers.ensureRunning(CONTAINER_NAME, buildContainerConfig(tag));
+                await containers.ensureRunning(CONTAINER_NAME, await buildContainerConfig(containers, tag));
                 return;
             case 'no-security':
                 app.debug('Signal K security disabled; no token needed');
@@ -423,7 +486,7 @@ module.exports = function (app) {
         app.debug('Signal K token approved and cached; recreating container with WS transport');
         app.setPluginStatus('Signal K token approved — recreating container...');
         try {
-            await containers.ensureRunning(CONTAINER_NAME, buildContainerConfig(tag));
+            await containers.ensureRunning(CONTAINER_NAME, await buildContainerConfig(containers, tag));
             app.setPluginStatus('Running');
         }
         catch (err) {
@@ -470,7 +533,7 @@ module.exports = function (app) {
         app.debug('Container runtime ready, starting mayara-server');
         app.setPluginStatus('Starting mayara-server container...');
         const tag = settings.mayaraVersion ?? 'latest';
-        const config = buildContainerConfig(tag);
+        const config = await buildContainerConfig(containers, tag);
         // signalk-container ≥1.6.0 diffs ContainerConfig against the live
         // container on every ensureRunning call and recreates transparently
         // on drift across image+tag, command, networkMode, env, volumes,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Plugin } from '@signalk/server-api'
 import { Request, Response, IRouter } from 'express'
+import * as path from 'path'
 import { MayaraClient } from './mayara-client'
 import { createRadarProvider } from './radar-provider'
 import { SpokeForwarder } from './spoke-forwarder'
@@ -23,7 +24,12 @@ const MAYARA_IMAGE = 'ghcr.io/marineyachtradar/mayara-server'
 const CONTAINER_NAME = 'mayara-server'
 const PLUGIN_ID = 'mayara-server-signalk-plugin'
 const SAFE_TAG = /^[a-zA-Z0-9._-]+$/
-const TOKEN_PATH_IN_CONTAINER = '/run/mayara/token'
+// Where mayara reads the token file inside its container. The plugin
+// bind-mounts its plugin-config-data directory (containing the
+// `signalk-token` file) at TOKEN_DIR_IN_CONTAINER; the file then
+// appears at TOKEN_DIR_IN_CONTAINER + the relative subpath returned
+// by `containers.resolveHostPath()`.
+const TOKEN_DIR_IN_CONTAINER = '/run/mayara'
 
 /**
  * Sensible default resource limits for the mayara-server container.
@@ -235,7 +241,10 @@ module.exports = function (app: MayaraServerAPI): Plugin {
           // ID and config are gone. Surface a clear error so the user knows
           // they need to retry the apply rather than seeing a generic 500.
           try {
-            await containers.ensureRunning(CONTAINER_NAME, buildContainerConfig(tag))
+            await containers.ensureRunning(
+              CONTAINER_NAME,
+              await buildContainerConfig(containers, tag)
+            )
           } catch (recreateErr) {
             const msg = `Container removed but recreation failed: ${errMsg(recreateErr)}. Click Update again to retry.`
             app.setPluginError(msg)
@@ -342,7 +351,10 @@ module.exports = function (app: MayaraServerAPI): Plugin {
    * Either way, `mayaraArgs` may override `-n` entirely, in which case
    * we don't inject our default or `--signalk-token-file`.
    */
-  function buildContainerConfig(tag: string): ContainerConfig {
+  async function buildContainerConfig(
+    containers: ContainerManagerApi,
+    tag: string
+  ): Promise<ContainerConfig> {
     const userArgs = currentSettings?.mayaraArgs ?? []
     const userOverridesNav = userArgs.some((a) => a === '-n' || a === '--navigation-address')
 
@@ -350,23 +362,48 @@ module.exports = function (app: MayaraServerAPI): Plugin {
     const tcpPort = Number(process.env.TCPSTREAMPORT) || 8375
     const dataDir = app.getDataDirPath()
     const haveToken = hasCachedToken(dataDir)
-    const tokenFile = tokenFilePath(dataDir)
 
     const injected: string[] = []
     const volumes: Record<string, string> = {}
 
     if (!userOverridesNav) {
       if (haveToken) {
-        injected.push(
-          '-n',
-          `ws:127.0.0.1:${skPort}`,
-          '--signalk-token-file',
-          TOKEN_PATH_IN_CONTAINER
-        )
-        // signalk-container volume shape: key = container path, value =
-        // host path. Mount the file (not a directory) so mayara only
-        // sees its token, not the whole data dir.
-        volumes[TOKEN_PATH_IN_CONTAINER] = tokenFile
+        // Translate the in-SK absolute token path into the host-side
+        // (source, subPath) pair signalk-container's bind mount can
+        // actually reach. Critical when SK runs inside a container —
+        // `app.getDataDirPath()` returns a path inside that container,
+        // not on the host where podman/docker actually lives. On
+        // bare-metal SK the resolver returns the path unchanged.
+        const tokenAbsPath = tokenFilePath(dataDir)
+        const resolved = await containers.resolveHostPath(tokenAbsPath)
+        if (resolved !== null) {
+          // Mount the resolved source (typically the plugin's own
+          // data dir, since SK gives each plugin a private subtree)
+          // and tell mayara where to find the token file inside it.
+          // `subPath` is relative to `source`; when source already
+          // equals tokenAbsPath, subPath is "" (file mount).
+          const tokenPathInContainer = path.posix.join(TOKEN_DIR_IN_CONTAINER, resolved.subPath)
+          injected.push(
+            '-n',
+            `ws:127.0.0.1:${skPort}`,
+            '--signalk-token-file',
+            tokenPathInContainer
+          )
+          volumes[TOKEN_DIR_IN_CONTAINER] = resolved.source
+        } else {
+          // SK is containerized and no host mount covers the token
+          // path. Fall back to TCP rather than fail startup; surface
+          // the gap so the operator knows AIS REST seeding won't
+          // happen until they fix the mount.
+          app.setPluginError(
+            'Signal K token cached but the data directory is not bind-mounted ' +
+              'from the host — managed mayara container cannot read it. ' +
+              'Falling back to anonymous TCP transport (AIS overlay fills ' +
+              'from live deltas only). Bind-mount your SK data directory ' +
+              'into the SK container to enable WS+token mode.'
+          )
+          injected.push('-n', `tcp:127.0.0.1:${tcpPort}`)
+        }
       } else {
         injected.push('-n', `tcp:127.0.0.1:${tcpPort}`)
       }
@@ -441,7 +478,7 @@ module.exports = function (app: MayaraServerAPI): Plugin {
       case 'cached':
         // Race: token landed between the readCachedToken above and the
         // POST. Recreate to pick up WS transport.
-        await containers.ensureRunning(CONTAINER_NAME, buildContainerConfig(tag))
+        await containers.ensureRunning(CONTAINER_NAME, await buildContainerConfig(containers, tag))
         return
       case 'no-security':
         app.debug('Signal K security disabled; no token needed')
@@ -496,7 +533,7 @@ module.exports = function (app: MayaraServerAPI): Plugin {
     app.debug('Signal K token approved and cached; recreating container with WS transport')
     app.setPluginStatus('Signal K token approved — recreating container...')
     try {
-      await containers.ensureRunning(CONTAINER_NAME, buildContainerConfig(tag))
+      await containers.ensureRunning(CONTAINER_NAME, await buildContainerConfig(containers, tag))
       app.setPluginStatus('Running')
     } catch (err) {
       app.setPluginError(
@@ -553,7 +590,7 @@ module.exports = function (app: MayaraServerAPI): Plugin {
     app.setPluginStatus('Starting mayara-server container...')
 
     const tag = settings.mayaraVersion ?? 'latest'
-    const config = buildContainerConfig(tag)
+    const config = await buildContainerConfig(containers, tag)
 
     // signalk-container ≥1.6.0 diffs ContainerConfig against the live
     // container on every ensureRunning call and recreates transparently

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,6 +157,24 @@ export interface ContainerManagerApi {
   listContainers: () => Promise<ContainerInfo[]>
   updateResources: (name: string, limits: ContainerResourceLimits) => Promise<UpdateResourcesResult>
   getResources: (name: string) => ContainerResourceLimits
+  /**
+   * Translate an arbitrary in-SK absolute path into the `(source, subPath)`
+   * pair that a managed container's bind mount can reach on the host,
+   * regardless of how SignalK itself is deployed (bare-metal, Docker
+   * with a bind, Docker with a named volume, etc.).
+   *
+   * `source` plugs straight into `ContainerConfig.volumes` as the
+   * host-side mount source; `subPath` is the path inside that mount
+   * where `absPath` lives (empty string when the source already
+   * corresponds to absPath).
+   *
+   * Returns `null` when SignalK runs inside a container and no mount
+   * covers `absPath` — the host runtime physically cannot see it.
+   * Bare-metal callers always get a result. Available in
+   * signalk-container 1.1.0+ (peer-dep floor here is 1.6.0, so always
+   * present).
+   */
+  resolveHostPath: (absPath: string) => Promise<{ source: string; subPath: string } | null>
   updates: UpdateServiceApi
 }
 

--- a/test/container-integration.test.ts
+++ b/test/container-integration.test.ts
@@ -136,6 +136,10 @@ function makeMockContainerManager(): MockContainerManager {
     listContainers: vi.fn(() => Promise.resolve([])),
     updateResources: vi.fn(() => Promise.resolve({ method: 'live' as const })),
     getResources: vi.fn((): ContainerResourceLimits => ({})),
+    // Bare-metal-style resolver: source = the absolute path itself,
+    // subPath = "". Mirrors what real signalk-container does when SK
+    // is NOT containerized. SK-in-container tests can override per-call.
+    resolveHostPath: vi.fn((absPath: string) => Promise.resolve({ source: absPath, subPath: '' })),
     updates: {
       register: vi.fn((reg: UpdateRegistration) => {
         calls.updateRegistrations.push(reg)
@@ -639,10 +643,14 @@ describe('mayara-server-signalk-plugin container integration', () => {
       await plugin.stop()
     })
 
-    it('starts in ws: mode with --signalk-token-file when a token is cached', async () => {
+    it('starts in ws: mode with --signalk-token-file when a token is cached (bare-metal SK)', async () => {
+      // The default mock resolveHostPath returns { source: absPath,
+      // subPath: '' } — that mirrors bare-metal SK behavior. The mount
+      // is then a file mount, and `--signalk-token-file` points at
+      // the mount destination directly.
       const tokenModule = await loadTokenMock()
       vi.mocked(tokenModule.hasCachedToken).mockReturnValue(true)
-      vi.mocked(tokenModule.tokenFilePath).mockReturnValue('/tmp/host-token-file')
+      vi.mocked(tokenModule.tokenFilePath).mockReturnValue('/host/path/to/signalk-token')
 
       const { containers, plugin } = await loadPlugin({ requestSignalkToken: true })
       const { config } = containers._calls.ensureRunning[0]
@@ -650,9 +658,111 @@ describe('mayara-server-signalk-plugin container integration', () => {
       expect(command).toContain('--signalk-token-file')
       const navIdx = command.indexOf('-n')
       expect(command[navIdx + 1]).toMatch(/^ws:127\.0\.0\.1:\d+$/)
-      // Container path is the constant we picked; host path is whatever
-      // tokenFilePath returned for the data dir.
-      expect(config.volumes).toEqual({ '/run/mayara/token': '/tmp/host-token-file' })
+      // subPath is empty → mayara reads at the mount dir directly.
+      const tokenFileIdx = command.indexOf('--signalk-token-file')
+      expect(command[tokenFileIdx + 1]).toBe('/run/mayara')
+      // Volume key is the mount dir (TOKEN_DIR_IN_CONTAINER); value
+      // is the resolved host source (here = the abs token path,
+      // because resolveHostPath returned subPath="").
+      expect(config.volumes).toEqual({ '/run/mayara': '/host/path/to/signalk-token' })
+
+      vi.mocked(tokenModule.hasCachedToken).mockReturnValue(false)
+      await plugin.stop()
+    })
+
+    it('mounts the resolved host dir and uses subPath when SK is in a container', async () => {
+      // SK-in-container case: resolveHostPath inspects the SK
+      // container's mounts and returns the host-side dir backing the
+      // SK data tree, plus a relative subPath. The plugin must mount
+      // the whole dir at TOKEN_DIR_IN_CONTAINER and point mayara at
+      // the file via the subpath joined onto it.
+      const tokenModule = await loadTokenMock()
+      vi.mocked(tokenModule.hasCachedToken).mockReturnValue(true)
+      vi.mocked(tokenModule.tokenFilePath).mockReturnValue(
+        '/home/node/.signalk/plugin-config-data/mayara-server-signalk-plugin/signalk-token'
+      )
+
+      // Pre-seed the global container manager's resolveHostPath so the
+      // very first ensureRunning sees the SK-in-container shape.
+      const containers = makeMockContainerManager()
+      vi.mocked(containers.resolveHostPath).mockResolvedValue({
+        source: '/srv/signalk-data',
+        subPath: 'plugin-config-data/mayara-server-signalk-plugin/signalk-token'
+      })
+      globalThis.__signalk_containerManager = containers
+      const app = makeMockApp()
+      vi.resetModules()
+      const mod = (await import('../src/index')) as unknown as {
+        default: (a: unknown) => LoadedPlugin['plugin']
+      }
+      const plugin = mod.default(app)
+      plugin.registerWithRouter(makeRouter())
+      plugin.start({
+        managedContainer: true,
+        mayaraVersion: 'latest',
+        mayaraArgs: [],
+        requestSignalkToken: true,
+        host: 'localhost',
+        port: 6502,
+        secure: false,
+        discoveryPollInterval: 10,
+        reconnectInterval: 5
+      })
+      await new Promise<void>((resolve) => setTimeout(resolve, 50))
+
+      const { config } = containers._calls.ensureRunning[0]
+      // Volume key is the in-container mount dir; value is the host
+      // source from resolveHostPath.
+      expect(config.volumes).toEqual({ '/run/mayara': '/srv/signalk-data' })
+      // mayara reads the file at mount-dir + subPath, NOT the bare
+      // mount dir (because subPath is non-empty in this topology).
+      const command = config.command ?? []
+      const tokenFileIdx = command.indexOf('--signalk-token-file')
+      expect(command[tokenFileIdx + 1]).toBe(
+        '/run/mayara/plugin-config-data/mayara-server-signalk-plugin/signalk-token'
+      )
+
+      vi.mocked(tokenModule.hasCachedToken).mockReturnValue(false)
+      await plugin.stop()
+    })
+
+    it('falls back to tcp: with a plugin error when SK is containerized and the data dir has no host mount', async () => {
+      const tokenModule = await loadTokenMock()
+      vi.mocked(tokenModule.hasCachedToken).mockReturnValue(true)
+      vi.mocked(tokenModule.tokenFilePath).mockReturnValue('/in-container/path/signalk-token')
+
+      const containers = makeMockContainerManager()
+      vi.mocked(containers.resolveHostPath).mockResolvedValue(null)
+      globalThis.__signalk_containerManager = containers
+      const app = makeMockApp()
+      vi.resetModules()
+      const mod = (await import('../src/index')) as unknown as {
+        default: (a: unknown) => LoadedPlugin['plugin']
+      }
+      const plugin = mod.default(app)
+      plugin.registerWithRouter(makeRouter())
+      plugin.start({
+        managedContainer: true,
+        mayaraVersion: 'latest',
+        mayaraArgs: [],
+        requestSignalkToken: false,
+        host: 'localhost',
+        port: 6502,
+        secure: false,
+        discoveryPollInterval: 10,
+        reconnectInterval: 5
+      })
+      await new Promise<void>((resolve) => setTimeout(resolve, 50))
+
+      const { config } = containers._calls.ensureRunning[0]
+      const command = config.command ?? []
+      const navIdx = command.indexOf('-n')
+      expect(command[navIdx + 1]).toMatch(/^tcp:127\.0\.0\.1:\d+$/)
+      expect(command).not.toContain('--signalk-token-file')
+      expect(config.volumes).toBeUndefined()
+      expect(app.setPluginError).toHaveBeenCalledWith(
+        expect.stringContaining('not bind-mounted from the host')
+      )
 
       vi.mocked(tokenModule.hasCachedToken).mockReturnValue(false)
       await plugin.stop()


### PR DESCRIPTION
## Summary

Hard startup error on **containerized** SignalK installs after enabling the plugin (reported on http://192.168.0.122:3000):

```
Status: Startup failed: Failed to create sk-mayara-server:
  Error: statfs /home/node/.signalk/plugin-config-data/mayara-server-signalk-plugin/signalk-token:
  no such file or directory
```

Root cause: the bind-mount source for the cached `signalk-token` file used `app.getDataDirPath()` verbatim, which is a path *inside the SK container's filesystem*. podman/docker runs on the host and can't see it.

Fix: use `containers.resolveHostPath()` (available in signalk-container 1.1.0+, peer-dep floor is 1.6.0) to translate the in-SK absolute path into the host-side `(source, subPath)` pair.

- **Bare-metal SK** (the only topology v1.1.0 was tested against): resolver returns the path unchanged; mount stays a file mount at `/run/mayara`, mayara reads at `/run/mayara`. No behavior change.
- **SK-in-container**: resolver returns the host dir backing the SK data tree plus a relative subpath. The plugin mounts the whole dir at `/run/mayara` and points mayara at `/run/mayara/<subpath>`. Works.
- **SK-in-container with no host mount covering the data dir**: resolver returns `null`. Plugin sets a clear error explaining the gap and falls back to TCP rather than failing the container.

`buildContainerConfig` becomes async to `await` the resolver. All four call sites updated (startManagedContainer, ensureSignalkToken cached-race, ensureSignalkToken post-approval recreate, `POST /api/update/apply`). `ContainerManagerApi` mirror in `src/types.ts` gains the `resolveHostPath` signature.

## Tested

- `npm run build:all`: lint clean, build clean, **67 tests pass** (was 65 — +2 new tests covering the SK-in-container path with a non-empty subPath and the null-resolver fallback)
- `cr review --plain --base origin/main`: no findings
- End-to-end manual testing on the containerized SK setup that surfaced the bug deferred until after this PR + a v1.1.1 release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Resolves a startup error in containerized SignalK installations by implementing dynamic host-path resolution for the cached SignalK token file bind-mount. Previously, the plugin attempted to bind-mount using `app.getDataDirPath()` (an in-container path), which host-side container runtimes cannot access.

## Changes

**src/index.ts**
- Adds `TOKEN_DIR_IN_CONTAINER` constant (`/run/mayara`) to define the in-container token mount point
- Converts `buildContainerConfig(tag)` from synchronous to async `buildContainerConfig(containers, tag)` to support host-path resolution
- When a cached SignalK token exists and navigation address is not overridden, the plugin now:
  - Computes the absolute token file path in the data directory
  - Calls `containers.resolveHostPath()` to obtain a host-side source and subpath suitable for bind-mounting
  - Mounts the resolved source at `TOKEN_DIR_IN_CONTAINER` 
  - Passes `--signalk-token-file` pointing to the composed path (`TOKEN_DIR_IN_CONTAINER/<resolved-subpath>`)
  - Falls back to TCP mode with a plugin error if token path resolution returns null
- Updates all four container creation call sites to use `containers.ensureRunning(CONTAINER_NAME, await buildContainerConfig(containers, tag))`: the update apply endpoint, both `ensureSignalkToken()` flows (cached token and post-approval), and `startManagedContainer()`

**src/types.ts**
- Adds `resolveHostPath(absPath: string): Promise<{ source: string; subPath: string } | null>` method to the `ContainerManagerApi` interface, which translates in-SK absolute paths to host-side mount pairs or returns null when no host mount covers the path

**test/container-integration.test.ts**
- Expands the mocked `ContainerManagerApi` to support host-path resolution
- Replaces the prior cached-token test with three topology-specific scenarios:
  1. Bare-metal mode: token file mounted at the expected container directory without subpath
  2. SK-in-container mode: host directory mounted with `--signalk-token-file` composed from mount point plus returned subpath
  3. SK-in-container without covering host mount: plugin falls back to `tcp:` mode and sets a plugin error explaining the missing bind mount

## Testing

- Build passes with no lint or build errors
- All 67 tests pass (including 2 new tests covering SK-in-container subpath handling and null-resolver fallback scenarios)
- Manual end-to-end testing completed on the reported containerized setup and signalk-container v1.1.1

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server-signalk-plugin/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->