### PR TITLE
chore(release): 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "signalk-plugin-enabled-by-default": true,


### PR DESCRIPTION
## Summary

Bumps `package.json` from `1.1.0` to `1.1.1`.

## What's shipping since 1.1.0

- **fix**: resolve token host path via signalk-container, so the managed mayara container can read the cached `signalk-token` when SignalK itself runs in a container (#34)

## Tested

- `npm run build:all`: lint clean, build clean, 67 tests pass
- `plugin/` build artifacts already current (rebuilt during #34)