### PR TITLE
fix(token): deliver Signal K token via env var instead of bind-mount

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,18 +94,20 @@ The flow lives in `src/signalk-token.ts` + `ensureSignalkToken()` in `src/index.
 
 1. On start, POST `/signalk/v1/access/requests` with `clientId = mayara-server-signalk-plugin` and `permissions: 'readwrite'`. The broad scope is deliberate — SK admin UI cannot widen permissions post-approval, only revoke + re-request, and mayara's roadmap includes pushing radar targets / MARPA tracks / notifications back to Signal K.
 2. Until the admin approves in **Security → Access Requests**, the container runs with `-n tcp:127.0.0.1:${TCPSTREAMPORT}` so nav deltas still flow.
-3. On approval, `awaitApproval()` extracts the JWT, caches it to `${app.getDataDirPath()}/signalk-token` (mode `0600`), and recreates the container with `-n ws:127.0.0.1:${PORT}` plus `--signalk-token-file /run/mayara/token` bind-mounted in.
-4. `requestSignalkToken: false` in plugin config opts out entirely (manual `--signalk-token-file` in `mayaraArgs` remains an escape hatch).
+3. On approval, `awaitApproval()` extracts the JWT, caches it to `${app.getDataDirPath()}/signalk-token` (mode `0600`, host-only), and recreates the container with `-n ws:127.0.0.1:${PORT}` plus `env.MAYARA_SIGNALK_TOKEN = <token>`. The token is delivered via env, not a bind-mounted file, because on docker / rootful podman signalk-container emits `--user 1000:1000` (the mayara image's USER) — and a 0600 file on the host owned by the SK process user would be unreadable from inside the container at that UID. Env vars cross the UID boundary unconditionally and `mayara-server` already accepts `MAYARA_SIGNALK_TOKEN` as an alternative to `--signalk-token-file` (see `mayara-server/src/lib/mod.rs:214-257`).
+4. `requestSignalkToken: false` in plugin config opts out entirely (manual `--signalk-token <token>` or `--signalk-token-file <path>` in `mayaraArgs` remains an escape hatch — and if the user passes `-n` in `mayaraArgs`, the plugin neither injects its default nor sets the token env, leaving the operator's config untouched).
 
 Token-flow tests live in `test/signalk-token.test.ts` (module-level: cache helpers, POST branches, polling) and `test/container-integration.test.ts` (integration: opt-in/out, lifecycle, recreate-on-approval). The token module is mocked by default in container-integration tests so they don't issue stray HTTP requests against a non-existent local SK; token-flow tests override per-test via `vi.mocked()`. The `tokenPollerCancelled` flag in `start()`/`stop()` keeps the poller from outliving the plugin.
 
 ### Container user UID mapping
 
-The mayara image declares `USER mayara` with UID/GID 1000. `buildContainerConfig` in `src/index.ts` declares `user: { inImageUid: 1000, inImageGid: 1000 }` so signalk-container emits the right uid-mapping flag — `--userns=keep-id:uid=1000,gid=1000` on rootless podman, `--user 1000:1000` on docker / rootful podman.
+The mayara image declares `USER mayara` with UID/GID 1000. `buildContainerConfig` in `src/index.ts` declares `user: { inImageUid: 1000, inImageGid: 1000 }` so signalk-container emits the right uid-mapping flag — `--userns=keep-id:uid=1000,gid=1000` on rootless podman, `--user 1000:1000` on docker / rootful podman (signalk-container ≥ the version that honors `inImageUid` on the docker/rootful branch).
 
-Without this, signalk-container defaults `inImageUid` to 0, the rootless-podman mapping puts the in-image UID 1000 at host UID `100999` (the subuid range), and the bind-mounted `signalk-token` file (mode `0600` owned by the SK server's host user) is unreadable from inside the container. The symptom is a crash-looping mayara container logging "Failed to install Signal K token: Permission denied".
+Without this, signalk-container defaults `inImageUid` to 0. On rootless podman the keep-id mapping puts the in-image UID 1000 at host UID `100999` (the subuid range); on docker / rootful podman the process runs as the SK host user's UID. Either way `/home/mayara/.local/share` (owned by uid 1000 inside the image) is unwritable and mayara fails to start.
 
-Test guard: "declares the mayara image in-image UID/GID for correct uid mapping" in `test/container-integration.test.ts`. Don't remove the `user` field from `buildContainerConfig` without first verifying that the bind-mount file ownership story still works on rootless podman.
+The token is delivered via the `MAYARA_SIGNALK_TOKEN` env var, not as a bind-mounted file, precisely so the in-container UID can differ from the host SK UID without breaking the upstream Signal K channel. See "Signal K device-token flow" above.
+
+Test guard: "declares the mayara image in-image UID/GID for correct uid mapping" in `test/container-integration.test.ts`. Don't remove the `user` field from `buildContainerConfig`; doing so silently regresses to whichever UID story the user's runtime defaults to.
 
 ### Build artifacts in `plugin/`
 

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,39 +1,5 @@
 "use strict";
-var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
-}) : (function(o, m, k, k2) {
-    if (k2 === undefined) k2 = k;
-    o[k2] = m[k];
-}));
-var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
-    Object.defineProperty(o, "default", { enumerable: true, value: v });
-}) : function(o, v) {
-    o["default"] = v;
-});
-var __importStar = (this && this.__importStar) || (function () {
-    var ownKeys = function(o) {
-        ownKeys = Object.getOwnPropertyNames || function (o) {
-            var ar = [];
-            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
-            return ar;
-        };
-        return ownKeys(o);
-    };
-    return function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
-        __setModuleDefault(result, mod);
-        return result;
-    };
-})();
 Object.defineProperty(exports, "__esModule", { value: true });
-const path = __importStar(require("path"));
 const mayara_client_1 = require("./mayara-client");
 const radar_provider_1 = require("./radar-provider");
 const spoke_forwarder_1 = require("./spoke-forwarder");
@@ -43,12 +9,6 @@ const MAYARA_IMAGE = 'ghcr.io/marineyachtradar/mayara-server';
 const CONTAINER_NAME = 'mayara-server';
 const PLUGIN_ID = 'mayara-server-signalk-plugin';
 const SAFE_TAG = /^[a-zA-Z0-9._-]+$/;
-// Where mayara reads the token file inside its container. The plugin
-// bind-mounts its plugin-config-data directory (containing the
-// `signalk-token` file) at TOKEN_DIR_IN_CONTAINER; the file then
-// appears at TOKEN_DIR_IN_CONTAINER + the relative subpath returned
-// by `containers.resolveHostPath()`.
-const TOKEN_DIR_IN_CONTAINER = '/run/mayara';
 /**
  * Sensible default resource limits for the mayara-server container.
  * Tested on a Pi 5 8GB with a Garmin xHD2 radar at 24 NM range.
@@ -242,7 +202,7 @@ module.exports = function (app) {
                     // ID and config are gone. Surface a clear error so the user knows
                     // they need to retry the apply rather than seeing a generic 500.
                     try {
-                        await containers.ensureRunning(CONTAINER_NAME, await buildContainerConfig(containers, tag));
+                        await containers.ensureRunning(CONTAINER_NAME, buildContainerConfig(tag));
                     }
                     catch (recreateErr) {
                         const msg = `Container removed but recreation failed: ${errMsg(recreateErr)}. Click Update again to retry.`;
@@ -321,61 +281,44 @@ module.exports = function (app) {
      * Build a ContainerConfig for the mayara-server container with the
      * given tag. Used at startup, when applying updates, and after a
      * background token mint completes — signalk-container drift-detects
-     * the resulting `command`/`volumes` changes and recreates the
-     * container transparently.
+     * the resulting `command`/`env` changes and recreates the container
+     * transparently.
      *
      * Default nav-address is the upstream Signal K server itself:
-     *   - `ws:127.0.0.1:${SK_PORT}` plus `--signalk-token-file` when a
-     *     cached device token exists (full WS path → AIS REST seeding
-     *     works inside the container).
+     *   - `ws:127.0.0.1:${SK_PORT}` plus `MAYARA_SIGNALK_TOKEN` env var
+     *     when a cached device token exists (full WS path → AIS REST
+     *     seeding works inside the container).
      *   - `tcp:127.0.0.1:${TCPSTREAMPORT}` otherwise (legacy delta
      *     stream; AIS overlay still works but only fills from live
      *     deltas, not the initial REST snapshot).
      *
      * Either way, `mayaraArgs` may override `-n` entirely, in which case
-     * we don't inject our default or `--signalk-token-file`.
+     * we don't inject our default — and we also drop the token env so
+     * the operator's explicit config isn't shadowed.
+     *
+     * The token is delivered via env, not as a bind-mounted file, because
+     * on Docker (and rootful podman) signalk-container emits `--user
+     * 1000:1000` so the in-container mayara user can write its own home —
+     * but that means the in-container UID (1000) differs from the host
+     * caller's UID and a bind-mounted 0600 token written by the host SK
+     * user would be unreadable from inside the container. Env vars cross
+     * the UID boundary unconditionally. The on-disk cache file under
+     * `${dataDir}/signalk-token` (mode 0600) stays as the plugin's own
+     * cache so the token survives SK restarts.
      */
-    async function buildContainerConfig(containers, tag) {
+    function buildContainerConfig(tag) {
         const userArgs = currentSettings?.mayaraArgs ?? [];
         const userOverridesNav = userArgs.some((a) => a === '-n' || a === '--navigation-address');
         const skPort = Number(process.env.PORT) || 3000;
         const tcpPort = Number(process.env.TCPSTREAMPORT) || 8375;
         const dataDir = app.getDataDirPath();
-        const haveToken = (0, signalk_token_1.hasCachedToken)(dataDir);
+        const cachedToken = userOverridesNav ? undefined : (0, signalk_token_1.readCachedToken)(dataDir);
         const injected = [];
-        const volumes = {};
+        const env = {};
         if (!userOverridesNav) {
-            if (haveToken) {
-                // Translate the in-SK absolute token path into the host-side
-                // (source, subPath) pair signalk-container's bind mount can
-                // actually reach. Critical when SK runs inside a container —
-                // `app.getDataDirPath()` returns a path inside that container,
-                // not on the host where podman/docker actually lives. On
-                // bare-metal SK the resolver returns the path unchanged.
-                const tokenAbsPath = (0, signalk_token_1.tokenFilePath)(dataDir);
-                const resolved = await containers.resolveHostPath(tokenAbsPath);
-                if (resolved !== null) {
-                    // Mount the resolved source (typically the plugin's own
-                    // data dir, since SK gives each plugin a private subtree)
-                    // and tell mayara where to find the token file inside it.
-                    // `subPath` is relative to `source`; when source already
-                    // equals tokenAbsPath, subPath is "" (file mount).
-                    const tokenPathInContainer = path.posix.join(TOKEN_DIR_IN_CONTAINER, resolved.subPath);
-                    injected.push('-n', `ws:127.0.0.1:${skPort}`, '--signalk-token-file', tokenPathInContainer);
-                    volumes[TOKEN_DIR_IN_CONTAINER] = resolved.source;
-                }
-                else {
-                    // SK is containerized and no host mount covers the token
-                    // path. Fall back to TCP rather than fail startup; surface
-                    // the gap so the operator knows AIS REST seeding won't
-                    // happen until they fix the mount.
-                    app.setPluginError('Signal K token cached but the data directory is not bind-mounted ' +
-                        'from the host — managed mayara container cannot read it. ' +
-                        'Falling back to anonymous TCP transport (AIS overlay fills ' +
-                        'from live deltas only). Bind-mount your SK data directory ' +
-                        'into the SK container to enable WS+token mode.');
-                    injected.push('-n', `tcp:127.0.0.1:${tcpPort}`);
-                }
+            if (cachedToken !== undefined) {
+                injected.push('-n', `ws:127.0.0.1:${skPort}`);
+                env.MAYARA_SIGNALK_TOKEN = cachedToken;
             }
             else {
                 injected.push('-n', `tcp:127.0.0.1:${tcpPort}`);
@@ -394,13 +337,12 @@ module.exports = function (app) {
             // (`--userns=keep-id:uid=1000,gid=1000` on rootless podman,
             // `--user 1000:1000` on docker / rootful podman). Without this
             // hint signalk-container assumes inImageUid=0, the in-image
-            // mayara user runs under the subuid range, and the bind-mounted
-            // signalk-token file (mode 0600 owned by the host SK user) is
-            // unreadable from inside the container.
+            // mayara user runs under the subuid range, and the in-container
+            // mayara process cannot write to `/home/mayara/.local/share`.
             user: { inImageUid: 1000, inImageGid: 1000 }
         };
-        if (Object.keys(volumes).length > 0) {
-            config.volumes = volumes;
+        if (Object.keys(env).length > 0) {
+            config.env = env;
         }
         return config;
     }
@@ -417,8 +359,8 @@ module.exports = function (app) {
      * Slow path: POST a request, surface "Awaiting approval" plugin
      * status, poll until admin approves (or denies, or stop() is
      * called). On approval, write the token and re-call ensureRunning
-     * so signalk-container drift-detects the new `command`/`volumes`
-     * and recreates the container.
+     * so signalk-container drift-detects the new `command`/`env` and
+     * recreates the container.
      */
     async function ensureSignalkToken(containers, tag) {
         const dataDir = app.getDataDirPath();
@@ -445,7 +387,7 @@ module.exports = function (app) {
             case 'cached':
                 // Race: token landed between the readCachedToken above and the
                 // POST. Recreate to pick up WS transport.
-                await containers.ensureRunning(CONTAINER_NAME, await buildContainerConfig(containers, tag));
+                await containers.ensureRunning(CONTAINER_NAME, buildContainerConfig(tag));
                 return;
             case 'no-security':
                 app.debug('Signal K security disabled; no token needed');
@@ -486,7 +428,7 @@ module.exports = function (app) {
         app.debug('Signal K token approved and cached; recreating container with WS transport');
         app.setPluginStatus('Signal K token approved — recreating container...');
         try {
-            await containers.ensureRunning(CONTAINER_NAME, await buildContainerConfig(containers, tag));
+            await containers.ensureRunning(CONTAINER_NAME, buildContainerConfig(tag));
             app.setPluginStatus('Running');
         }
         catch (err) {
@@ -533,7 +475,7 @@ module.exports = function (app) {
         app.debug('Container runtime ready, starting mayara-server');
         app.setPluginStatus('Starting mayara-server container...');
         const tag = settings.mayaraVersion ?? 'latest';
-        const config = await buildContainerConfig(containers, tag);
+        const config = buildContainerConfig(tag);
         // signalk-container ≥1.6.0 diffs ContainerConfig against the live
         // container on every ensureRunning call and recreates transparently
         // on drift across image+tag, command, networkMode, env, volumes,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import { Plugin } from '@signalk/server-api'
 import { Request, Response, IRouter } from 'express'
-import * as path from 'path'
 import { MayaraClient } from './mayara-client'
 import { createRadarProvider } from './radar-provider'
 import { SpokeForwarder } from './spoke-forwarder'
@@ -14,9 +13,7 @@ import { ConfigSchema, Config, SCHEMA_DEFAULTS } from './config/schema'
 import {
   awaitApproval,
   beginTokenRequest,
-  hasCachedToken,
   readCachedToken,
-  tokenFilePath,
   writeCachedToken
 } from './signalk-token'
 
@@ -24,12 +21,6 @@ const MAYARA_IMAGE = 'ghcr.io/marineyachtradar/mayara-server'
 const CONTAINER_NAME = 'mayara-server'
 const PLUGIN_ID = 'mayara-server-signalk-plugin'
 const SAFE_TAG = /^[a-zA-Z0-9._-]+$/
-// Where mayara reads the token file inside its container. The plugin
-// bind-mounts its plugin-config-data directory (containing the
-// `signalk-token` file) at TOKEN_DIR_IN_CONTAINER; the file then
-// appears at TOKEN_DIR_IN_CONTAINER + the relative subpath returned
-// by `containers.resolveHostPath()`.
-const TOKEN_DIR_IN_CONTAINER = '/run/mayara'
 
 /**
  * Sensible default resource limits for the mayara-server container.
@@ -241,10 +232,7 @@ module.exports = function (app: MayaraServerAPI): Plugin {
           // ID and config are gone. Surface a clear error so the user knows
           // they need to retry the apply rather than seeing a generic 500.
           try {
-            await containers.ensureRunning(
-              CONTAINER_NAME,
-              await buildContainerConfig(containers, tag)
-            )
+            await containers.ensureRunning(CONTAINER_NAME, buildContainerConfig(tag))
           } catch (recreateErr) {
             const msg = `Container removed but recreation failed: ${errMsg(recreateErr)}. Click Update again to retry.`
             app.setPluginError(msg)
@@ -337,73 +325,47 @@ module.exports = function (app: MayaraServerAPI): Plugin {
    * Build a ContainerConfig for the mayara-server container with the
    * given tag. Used at startup, when applying updates, and after a
    * background token mint completes — signalk-container drift-detects
-   * the resulting `command`/`volumes` changes and recreates the
-   * container transparently.
+   * the resulting `command`/`env` changes and recreates the container
+   * transparently.
    *
    * Default nav-address is the upstream Signal K server itself:
-   *   - `ws:127.0.0.1:${SK_PORT}` plus `--signalk-token-file` when a
-   *     cached device token exists (full WS path → AIS REST seeding
-   *     works inside the container).
+   *   - `ws:127.0.0.1:${SK_PORT}` plus `MAYARA_SIGNALK_TOKEN` env var
+   *     when a cached device token exists (full WS path → AIS REST
+   *     seeding works inside the container).
    *   - `tcp:127.0.0.1:${TCPSTREAMPORT}` otherwise (legacy delta
    *     stream; AIS overlay still works but only fills from live
    *     deltas, not the initial REST snapshot).
    *
    * Either way, `mayaraArgs` may override `-n` entirely, in which case
-   * we don't inject our default or `--signalk-token-file`.
+   * we don't inject our default — and we also drop the token env so
+   * the operator's explicit config isn't shadowed.
+   *
+   * The token is delivered via env, not as a bind-mounted file, because
+   * on Docker (and rootful podman) signalk-container emits `--user
+   * 1000:1000` so the in-container mayara user can write its own home —
+   * but that means the in-container UID (1000) differs from the host
+   * caller's UID and a bind-mounted 0600 token written by the host SK
+   * user would be unreadable from inside the container. Env vars cross
+   * the UID boundary unconditionally. The on-disk cache file under
+   * `${dataDir}/signalk-token` (mode 0600) stays as the plugin's own
+   * cache so the token survives SK restarts.
    */
-  async function buildContainerConfig(
-    containers: ContainerManagerApi,
-    tag: string
-  ): Promise<ContainerConfig> {
+  function buildContainerConfig(tag: string): ContainerConfig {
     const userArgs = currentSettings?.mayaraArgs ?? []
     const userOverridesNav = userArgs.some((a) => a === '-n' || a === '--navigation-address')
 
     const skPort = Number(process.env.PORT) || 3000
     const tcpPort = Number(process.env.TCPSTREAMPORT) || 8375
     const dataDir = app.getDataDirPath()
-    const haveToken = hasCachedToken(dataDir)
+    const cachedToken = userOverridesNav ? undefined : readCachedToken(dataDir)
 
     const injected: string[] = []
-    const volumes: Record<string, string> = {}
+    const env: Record<string, string> = {}
 
     if (!userOverridesNav) {
-      if (haveToken) {
-        // Translate the in-SK absolute token path into the host-side
-        // (source, subPath) pair signalk-container's bind mount can
-        // actually reach. Critical when SK runs inside a container —
-        // `app.getDataDirPath()` returns a path inside that container,
-        // not on the host where podman/docker actually lives. On
-        // bare-metal SK the resolver returns the path unchanged.
-        const tokenAbsPath = tokenFilePath(dataDir)
-        const resolved = await containers.resolveHostPath(tokenAbsPath)
-        if (resolved !== null) {
-          // Mount the resolved source (typically the plugin's own
-          // data dir, since SK gives each plugin a private subtree)
-          // and tell mayara where to find the token file inside it.
-          // `subPath` is relative to `source`; when source already
-          // equals tokenAbsPath, subPath is "" (file mount).
-          const tokenPathInContainer = path.posix.join(TOKEN_DIR_IN_CONTAINER, resolved.subPath)
-          injected.push(
-            '-n',
-            `ws:127.0.0.1:${skPort}`,
-            '--signalk-token-file',
-            tokenPathInContainer
-          )
-          volumes[TOKEN_DIR_IN_CONTAINER] = resolved.source
-        } else {
-          // SK is containerized and no host mount covers the token
-          // path. Fall back to TCP rather than fail startup; surface
-          // the gap so the operator knows AIS REST seeding won't
-          // happen until they fix the mount.
-          app.setPluginError(
-            'Signal K token cached but the data directory is not bind-mounted ' +
-              'from the host — managed mayara container cannot read it. ' +
-              'Falling back to anonymous TCP transport (AIS overlay fills ' +
-              'from live deltas only). Bind-mount your SK data directory ' +
-              'into the SK container to enable WS+token mode.'
-          )
-          injected.push('-n', `tcp:127.0.0.1:${tcpPort}`)
-        }
+      if (cachedToken !== undefined) {
+        injected.push('-n', `ws:127.0.0.1:${skPort}`)
+        env.MAYARA_SIGNALK_TOKEN = cachedToken
       } else {
         injected.push('-n', `tcp:127.0.0.1:${tcpPort}`)
       }
@@ -423,13 +385,12 @@ module.exports = function (app: MayaraServerAPI): Plugin {
       // (`--userns=keep-id:uid=1000,gid=1000` on rootless podman,
       // `--user 1000:1000` on docker / rootful podman). Without this
       // hint signalk-container assumes inImageUid=0, the in-image
-      // mayara user runs under the subuid range, and the bind-mounted
-      // signalk-token file (mode 0600 owned by the host SK user) is
-      // unreadable from inside the container.
+      // mayara user runs under the subuid range, and the in-container
+      // mayara process cannot write to `/home/mayara/.local/share`.
       user: { inImageUid: 1000, inImageGid: 1000 }
     }
-    if (Object.keys(volumes).length > 0) {
-      config.volumes = volumes
+    if (Object.keys(env).length > 0) {
+      config.env = env
     }
     return config
   }
@@ -447,8 +408,8 @@ module.exports = function (app: MayaraServerAPI): Plugin {
    * Slow path: POST a request, surface "Awaiting approval" plugin
    * status, poll until admin approves (or denies, or stop() is
    * called). On approval, write the token and re-call ensureRunning
-   * so signalk-container drift-detects the new `command`/`volumes`
-   * and recreates the container.
+   * so signalk-container drift-detects the new `command`/`env` and
+   * recreates the container.
    */
   async function ensureSignalkToken(containers: ContainerManagerApi, tag: string): Promise<void> {
     const dataDir = app.getDataDirPath()
@@ -478,7 +439,7 @@ module.exports = function (app: MayaraServerAPI): Plugin {
       case 'cached':
         // Race: token landed between the readCachedToken above and the
         // POST. Recreate to pick up WS transport.
-        await containers.ensureRunning(CONTAINER_NAME, await buildContainerConfig(containers, tag))
+        await containers.ensureRunning(CONTAINER_NAME, buildContainerConfig(tag))
         return
       case 'no-security':
         app.debug('Signal K security disabled; no token needed')
@@ -533,7 +494,7 @@ module.exports = function (app: MayaraServerAPI): Plugin {
     app.debug('Signal K token approved and cached; recreating container with WS transport')
     app.setPluginStatus('Signal K token approved — recreating container...')
     try {
-      await containers.ensureRunning(CONTAINER_NAME, await buildContainerConfig(containers, tag))
+      await containers.ensureRunning(CONTAINER_NAME, buildContainerConfig(tag))
       app.setPluginStatus('Running')
     } catch (err) {
       app.setPluginError(
@@ -590,7 +551,7 @@ module.exports = function (app: MayaraServerAPI): Plugin {
     app.setPluginStatus('Starting mayara-server container...')
 
     const tag = settings.mayaraVersion ?? 'latest'
-    const config = await buildContainerConfig(containers, tag)
+    const config = buildContainerConfig(tag)
 
     // signalk-container ≥1.6.0 diffs ContainerConfig against the live
     // container on every ensureRunning call and recreates transparently

--- a/test/container-integration.test.ts
+++ b/test/container-integration.test.ts
@@ -51,8 +51,6 @@ vi.mock('../src/signalk-token', async () => {
     ...actual,
     readCachedToken: vi.fn(() => undefined),
     writeCachedToken: vi.fn(),
-    hasCachedToken: vi.fn(() => false),
-    tokenFilePath: vi.fn((dir: string) => `${dir}/signalk-token`),
     beginTokenRequest: vi.fn(() =>
       Promise.resolve({ kind: 'error' as const, message: 'stubbed in tests' })
     ),
@@ -345,10 +343,6 @@ beforeEach(async () => {
   const tokenModule = await loadTokenMock()
   vi.mocked(tokenModule.readCachedToken).mockReset().mockReturnValue(undefined)
   vi.mocked(tokenModule.writeCachedToken).mockReset()
-  vi.mocked(tokenModule.hasCachedToken).mockReset().mockReturnValue(false)
-  vi.mocked(tokenModule.tokenFilePath)
-    .mockReset()
-    .mockImplementation((dir: string) => `${dir}/signalk-token`)
   vi.mocked(tokenModule.beginTokenRequest)
     .mockReset()
     .mockResolvedValue({ kind: 'error', message: 'stubbed in tests' })
@@ -404,9 +398,13 @@ describe('mayara-server-signalk-plugin container integration', () => {
 
     it('declares the mayara image in-image UID/GID for correct uid mapping', async () => {
       // The mayara image runs as `mayara` (UID 1000). signalk-container
-      // defaults inImageUid to 0 when this field is omitted, which on
-      // rootless podman puts the container in the subuid range and
-      // breaks bind-mounted host files (notably the signalk-token).
+      // defaults inImageUid to 0 when this field is omitted; without the
+      // explicit declaration the rootless-podman keep-id mapping would
+      // put the container in the subuid range, and on docker / rootful
+      // podman the in-container process would run under the SK host
+      // user's UID instead of the image's mayara user — either way,
+      // `/home/mayara/.local/share` (owned by uid 1000 inside the image)
+      // is unwritable and mayara fails to start.
       const { containers, plugin } = await loadPlugin()
       const { config } = containers._calls.ensureRunning[0]
       expect(config.user).toEqual({ inImageUid: 1000, inImageGid: 1000 })
@@ -639,138 +637,36 @@ describe('mayara-server-signalk-plugin container integration', () => {
       expect(config.command?.[1]).toBe('-n')
       expect(config.command?.[2]).toMatch(/^tcp:127\.0\.0\.1:\d+$/)
       expect(config.command).not.toContain('--signalk-token-file')
+      expect(config.env?.MAYARA_SIGNALK_TOKEN).toBeUndefined()
       expect(config.volumes).toBeUndefined()
       await plugin.stop()
     })
 
-    it('starts in ws: mode with --signalk-token-file when a token is cached (bare-metal SK)', async () => {
-      // The default mock resolveHostPath returns { source: absPath,
-      // subPath: '' } — that mirrors bare-metal SK behavior. The mount
-      // is then a file mount, and `--signalk-token-file` points at
-      // the mount destination directly.
+    it('starts in ws: mode with MAYARA_SIGNALK_TOKEN env var when a token is cached', async () => {
+      // The plugin delivers the token via env, not a bind-mounted
+      // file, so the in-container mayara user (uid 1000) can read it
+      // regardless of the host file's owner. No host-path resolution
+      // or bind-mount needed.
       const tokenModule = await loadTokenMock()
-      vi.mocked(tokenModule.hasCachedToken).mockReturnValue(true)
-      vi.mocked(tokenModule.tokenFilePath).mockReturnValue('/host/path/to/signalk-token')
+      vi.mocked(tokenModule.readCachedToken).mockReturnValue('cached-jwt-abc')
 
       const { containers, plugin } = await loadPlugin({ requestSignalkToken: true })
       const { config } = containers._calls.ensureRunning[0]
       const command = config.command ?? []
-      expect(command).toContain('--signalk-token-file')
+      expect(command).not.toContain('--signalk-token-file')
       const navIdx = command.indexOf('-n')
       expect(command[navIdx + 1]).toMatch(/^ws:127\.0\.0\.1:\d+$/)
-      // subPath is empty → mayara reads at the mount dir directly.
-      const tokenFileIdx = command.indexOf('--signalk-token-file')
-      expect(command[tokenFileIdx + 1]).toBe('/run/mayara')
-      // Volume key is the mount dir (TOKEN_DIR_IN_CONTAINER); value
-      // is the resolved host source (here = the abs token path,
-      // because resolveHostPath returned subPath="").
-      expect(config.volumes).toEqual({ '/run/mayara': '/host/path/to/signalk-token' })
-
-      vi.mocked(tokenModule.hasCachedToken).mockReturnValue(false)
-      await plugin.stop()
-    })
-
-    it('mounts the resolved host dir and uses subPath when SK is in a container', async () => {
-      // SK-in-container case: resolveHostPath inspects the SK
-      // container's mounts and returns the host-side dir backing the
-      // SK data tree, plus a relative subPath. The plugin must mount
-      // the whole dir at TOKEN_DIR_IN_CONTAINER and point mayara at
-      // the file via the subpath joined onto it.
-      const tokenModule = await loadTokenMock()
-      vi.mocked(tokenModule.hasCachedToken).mockReturnValue(true)
-      vi.mocked(tokenModule.tokenFilePath).mockReturnValue(
-        '/home/node/.signalk/plugin-config-data/mayara-server-signalk-plugin/signalk-token'
-      )
-
-      // Pre-seed the global container manager's resolveHostPath so the
-      // very first ensureRunning sees the SK-in-container shape.
-      const containers = makeMockContainerManager()
-      vi.mocked(containers.resolveHostPath).mockResolvedValue({
-        source: '/srv/signalk-data',
-        subPath: 'plugin-config-data/mayara-server-signalk-plugin/signalk-token'
-      })
-      globalThis.__signalk_containerManager = containers
-      const app = makeMockApp()
-      vi.resetModules()
-      const mod = (await import('../src/index')) as unknown as {
-        default: (a: unknown) => LoadedPlugin['plugin']
-      }
-      const plugin = mod.default(app)
-      plugin.registerWithRouter(makeRouter())
-      plugin.start({
-        managedContainer: true,
-        mayaraVersion: 'latest',
-        mayaraArgs: [],
-        requestSignalkToken: true,
-        host: 'localhost',
-        port: 6502,
-        secure: false,
-        discoveryPollInterval: 10,
-        reconnectInterval: 5
-      })
-      await new Promise<void>((resolve) => setTimeout(resolve, 50))
-
-      const { config } = containers._calls.ensureRunning[0]
-      // Volume key is the in-container mount dir; value is the host
-      // source from resolveHostPath.
-      expect(config.volumes).toEqual({ '/run/mayara': '/srv/signalk-data' })
-      // mayara reads the file at mount-dir + subPath, NOT the bare
-      // mount dir (because subPath is non-empty in this topology).
-      const command = config.command ?? []
-      const tokenFileIdx = command.indexOf('--signalk-token-file')
-      expect(command[tokenFileIdx + 1]).toBe(
-        '/run/mayara/plugin-config-data/mayara-server-signalk-plugin/signalk-token'
-      )
-
-      vi.mocked(tokenModule.hasCachedToken).mockReturnValue(false)
-      await plugin.stop()
-    })
-
-    it('falls back to tcp: with a plugin error when SK is containerized and the data dir has no host mount', async () => {
-      const tokenModule = await loadTokenMock()
-      vi.mocked(tokenModule.hasCachedToken).mockReturnValue(true)
-      vi.mocked(tokenModule.tokenFilePath).mockReturnValue('/in-container/path/signalk-token')
-
-      const containers = makeMockContainerManager()
-      vi.mocked(containers.resolveHostPath).mockResolvedValue(null)
-      globalThis.__signalk_containerManager = containers
-      const app = makeMockApp()
-      vi.resetModules()
-      const mod = (await import('../src/index')) as unknown as {
-        default: (a: unknown) => LoadedPlugin['plugin']
-      }
-      const plugin = mod.default(app)
-      plugin.registerWithRouter(makeRouter())
-      plugin.start({
-        managedContainer: true,
-        mayaraVersion: 'latest',
-        mayaraArgs: [],
-        requestSignalkToken: false,
-        host: 'localhost',
-        port: 6502,
-        secure: false,
-        discoveryPollInterval: 10,
-        reconnectInterval: 5
-      })
-      await new Promise<void>((resolve) => setTimeout(resolve, 50))
-
-      const { config } = containers._calls.ensureRunning[0]
-      const command = config.command ?? []
-      const navIdx = command.indexOf('-n')
-      expect(command[navIdx + 1]).toMatch(/^tcp:127\.0\.0\.1:\d+$/)
-      expect(command).not.toContain('--signalk-token-file')
+      expect(config.env).toEqual({ MAYARA_SIGNALK_TOKEN: 'cached-jwt-abc' })
+      // No bind mount needed for the token under env-var delivery.
       expect(config.volumes).toBeUndefined()
-      expect(app.setPluginError).toHaveBeenCalledWith(
-        expect.stringContaining('not bind-mounted from the host')
-      )
 
-      vi.mocked(tokenModule.hasCachedToken).mockReturnValue(false)
+      vi.mocked(tokenModule.readCachedToken).mockReturnValue(undefined)
       await plugin.stop()
     })
 
-    it('respects user-overridden -n by not injecting ws nor --signalk-token-file', async () => {
+    it('respects user-overridden -n by not injecting ws nor the token env var', async () => {
       const tokenModule = await loadTokenMock()
-      vi.mocked(tokenModule.hasCachedToken).mockReturnValue(true)
+      vi.mocked(tokenModule.readCachedToken).mockReturnValue('cached-jwt-abc')
 
       const { containers, plugin } = await loadPlugin({
         requestSignalkToken: true,
@@ -780,9 +676,14 @@ describe('mayara-server-signalk-plugin container integration', () => {
       expect(config.command?.filter((a) => a === '-n').length).toBe(1)
       expect(config.command).toContain('tcp:0.0.0.0:9999')
       expect(config.command).not.toContain('--signalk-token-file')
+      // User explicitly chose a transport; don't shadow it with our
+      // token env (mayara would still pick it up for the WS path if
+      // the user navigated back to ws:, but the operator's explicit
+      // override wins).
+      expect(config.env?.MAYARA_SIGNALK_TOKEN).toBeUndefined()
       expect(config.volumes).toBeUndefined()
 
-      vi.mocked(tokenModule.hasCachedToken).mockReturnValue(false)
+      vi.mocked(tokenModule.readCachedToken).mockReturnValue(undefined)
       await plugin.stop()
     })
 
@@ -830,13 +731,13 @@ describe('mayara-server-signalk-plugin container integration', () => {
       })
       vi.mocked(tokenModule.awaitApproval).mockResolvedValue('approved-jwt')
       // After awaitApproval resolves, the plugin writes the token and
-      // re-calls ensureRunning. The second call should see hasCachedToken
-      // returning true so the new config uses ws:/--signalk-token-file.
-      let approved = false
-      vi.mocked(tokenModule.hasCachedToken).mockImplementation(() => approved)
-      vi.mocked(tokenModule.tokenFilePath).mockReturnValue('/tmp/host-token-file')
-      vi.mocked(tokenModule.writeCachedToken).mockImplementation(() => {
-        approved = true
+      // re-calls ensureRunning. The second call's buildContainerConfig
+      // must see the cached token via readCachedToken so the new config
+      // delivers it via env + uses ws: transport.
+      let cached: string | undefined
+      vi.mocked(tokenModule.readCachedToken).mockImplementation(() => cached)
+      vi.mocked(tokenModule.writeCachedToken).mockImplementation((_dir, token) => {
+        cached = token
       })
 
       const { plugin, containers } = await loadPlugin({ requestSignalkToken: true })
@@ -847,13 +748,16 @@ describe('mayara-server-signalk-plugin container integration', () => {
 
       // Should have called writeCachedToken once with the approved token.
       expect(tokenModule.writeCachedToken).toHaveBeenCalledWith(expect.any(String), 'approved-jwt')
-      // ensureRunning called twice: first with tcp config, then with ws
-      // config after the token landed.
+      // ensureRunning called twice: first with tcp config (no token yet),
+      // then with ws config after the token landed.
       expect(containers._calls.ensureRunning.length).toBeGreaterThanOrEqual(2)
       const lastCall = containers._calls.ensureRunning[containers._calls.ensureRunning.length - 1]
-      expect(lastCall.config.command).toContain('--signalk-token-file')
+      expect(lastCall.config.env?.MAYARA_SIGNALK_TOKEN).toBe('approved-jwt')
+      const lastCmd = lastCall.config.command ?? []
+      const navIdx = lastCmd.indexOf('-n')
+      expect(lastCmd[navIdx + 1]).toMatch(/^ws:127\.0\.0\.1:\d+$/)
 
-      vi.mocked(tokenModule.hasCachedToken).mockReturnValue(false)
+      vi.mocked(tokenModule.readCachedToken).mockReturnValue(undefined)
       await plugin.stop()
     })
 


### PR DESCRIPTION
## Summary

- mayara container on Docker (and rootful Podman) fails to read the bind-mounted `signalk-token` because the in-container mayara user (uid 1000) and the host SK process owner (e.g. uid 1011) don't match — the 0600 file is unreadable across that UID boundary, and the container exits with `Failed to install Signal K token: Permission denied`.
- mayara-server already accepts `MAYARA_SIGNALK_TOKEN` as an alternative to `--signalk-token-file` ([mayara-server src/lib/mod.rs:214-257](https://github.com/MarineYachtRadar/mayara-server/blob/main/src/lib/mod.rs#L214-L257)). Switch the plugin to deliver the token that way — env vars cross the UID boundary unconditionally, no bind-mount needed.
- Drops `TOKEN_DIR_IN_CONTAINER`, the `resolveHostPath` translation step, and the SK-in-container "no host mount covers the token path" fallback: env-var delivery makes the question moot. The on-disk cache file at `${dataDir}/signalk-token` (0600, host-only) stays as the plugin's own cache so the token survives SK restarts.

This complements an in-flight signalk-container fix that will start respecting the declared `inImageUid` on docker / rootful podman (so the in-container process correctly becomes uid 1000 instead of the host UID). This PR is forward-compatible with both the pre-fix and post-fix signalk-container: env vars work either way.

## Tested

- `npm run build:all` — 65/65 vitest tests pass, lint clean, webpack build succeeds.
- Bind-mount-flavored tests in `test/container-integration.test.ts` rewritten to assert `config.env.MAYARA_SIGNALK_TOKEN` and the absence of `--signalk-token-file` / `/run/mayara` mounts.
- Approval-recreate test confirms the recreated container picks up the new env entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Problem

The mayara container encounters permission errors when reading a bind-mounted Signal K token file, because the in-container mayara user (uid 1000) differs from the host Signal K process owner. Token files owned by the host with 0600 permissions are unreadable inside the container, causing container startup failures.

## Solution

Delivers the Signal K token to mayara-server via the `MAYARA_SIGNALK_TOKEN` environment variable instead of bind-mounting a token file. The cached token is still persisted on disk at `${dataDir}/signalk-token` for durability across Signal K restarts.

## Changes

**src/index.ts**
- Refactors `buildContainerConfig()` from an async function that resolved host paths and configured bind mounts into a synchronous function that reads the cached token and injects it as an environment variable
- Removes `TOKEN_DIR_IN_CONTAINER` constant and the bind-mount volume configuration for the token file
- Eliminates the host-path resolution step (`resolveHostPath`) and fallback logic for missing mount coverage
- Removes `--signalk-token-file` command-line argument; token is now delivered via `MAYARA_SIGNALK_TOKEN` when the navigation address has not been overridden by the operator
- Updates all call sites (update apply, token acquisition, container startup) to use the simplified synchronous builder

**AGENTS.md**
- Documents the new token delivery flow: cached JWT passed via environment variable and WebSocket transport instead of bind-mounted files
- Clarifies `requestSignalkToken: false` opt-out behavior and interaction with user-provided `mayaraArgs`
- Updates the "Container user UID mapping" section to reflect the removal of bind-mount-based permission failures

**test/container-integration.test.ts**
- Removes `hasCachedToken` and `tokenFilePath` stub methods; token presence is now controlled via `readCachedToken` and `writeCachedToken`
- Updates Signal K token integration tests to assert `MAYARA_SIGNALK_TOKEN` environment variable is set and that WebSocket transport is used when a cached token exists
- Adds assertions ensuring the token environment variable is not injected when the operator explicitly sets the navigation address
- Refactors the admin-approval token flow test to verify the recreated container receives `MAYARA_SIGNALK_TOKEN=approved-jwt`
- Removes older transport and mount-focused token tests that are no longer applicable

## Compatibility

The change is forward-compatible with both current signalk-container behavior and an in-flight fix that runs the containerized Signal K process as uid 1000; environment variable delivery works in both cases.

## Testing

All 65 vitest tests pass, lint is clean, and webpack build succeeds. Container integration tests verify config includes `MAYARA_SIGNALK_TOKEN` environment variable and absence of `--signalk-token-file` / `/run/mayara` mounts. Approval-recreate test confirms the recreated container receives the new env entry.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server-signalk-plugin/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->