### PR TITLE
chore(release): 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "signalk-plugin-enabled-by-default": true,


### PR DESCRIPTION
## Summary

- Patch release covering the env-var token delivery fix merged in #38.

## Shipping in 1.1.2

- `fix(token): deliver Signal K token via env var instead of bind-mount` (#38) — mayara container on Docker no longer crashes with `Failed to install Signal K token: Permission denied`. Token is delivered via `MAYARA_SIGNALK_TOKEN` env var (cross-UID readable) instead of a bind-mounted 0600 file.

## Tested

- `npm run build:all` — 65/65 tests pass, lint clean, webpack build succeeds.