### PR TITLE
feat: forward mayara notifications.* deltas to upstream Signal K

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -3,6 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const mayara_client_1 = require("./mayara-client");
 const radar_provider_1 = require("./radar-provider");
 const spoke_forwarder_1 = require("./spoke-forwarder");
+const notification_forwarder_1 = require("./notification-forwarder");
 const schema_1 = require("./config/schema");
 const signalk_token_1 = require("./signalk-token");
 const MAYARA_IMAGE = 'ghcr.io/marineyachtradar/mayara-server';
@@ -38,6 +39,10 @@ module.exports = function (app) {
     let client = null;
     let currentSettings = null;
     const spokeForwarders = new Map();
+    // Single instance: mayara emits notifications on the server-wide v1
+    // stream, not per-radar, so we only need one connection regardless of
+    // how many radars are discovered.
+    let notificationForwarder = null;
     let discoveryInterval = null;
     // Set true on stop() so the in-flight token poller exits its loop.
     let tokenPollerCancelled = false;
@@ -89,6 +94,10 @@ module.exports = function (app) {
             }
             spokeForwarders.clear();
             knownRadars.clear();
+            if (notificationForwarder) {
+                notificationForwarder.stop();
+                notificationForwarder = null;
+            }
             if (client) {
                 client.close();
                 client = null;
@@ -148,6 +157,9 @@ module.exports = function (app) {
                         radarId: id,
                         connected: spokeForwarders.get(id)?.isConnected() ?? false
                     })),
+                    notificationForwarder: {
+                        connected: notificationForwarder?.isConnected() ?? false
+                    },
                     container: {
                         state: containerState,
                         image: containerImage,
@@ -551,6 +563,19 @@ module.exports = function (app) {
                     await new Promise((resolve) => setTimeout(resolve, 1000));
                 }
             }
+        }
+        // Bring up the notification forwarder before discovery so the very
+        // first guard-zone alarm a radar fires reaches the upstream Signal
+        // K server. The forwarder owns its own reconnect loop, so failing
+        // here just means it'll reach mayara on a later attempt.
+        if (!notificationForwarder) {
+            notificationForwarder = new notification_forwarder_1.NotificationForwarder(app, {
+                pluginId: PLUGIN_ID,
+                url: client.getStateStreamUrl(),
+                debug: app.debug.bind(app),
+                reconnectInterval: (settings.reconnectInterval || 5) * 1000
+            });
+            notificationForwarder.start();
         }
         await connectAndDiscover(settings);
     }

--- a/plugin/mayara-client.js
+++ b/plugin/mayara-client.js
@@ -97,6 +97,15 @@ class MayaraClient {
         const wsProtocol = this.secure ? 'wss' : 'ws';
         return `${wsProtocol}://${this.host}:${this.port}${API_BASE}/${radarId}/targets/stream`;
     }
+    /**
+     * Signal K v1 stream — the same WebSocket the built-in GUI subscribes
+     * to. Used by NotificationForwarder to listen for `notifications.*`
+     * deltas (e.g. guard-zone alarms) and republish them upstream.
+     */
+    getStateStreamUrl() {
+        const wsProtocol = this.secure ? 'wss' : 'ws';
+        return `${wsProtocol}://${this.host}:${this.port}/signalk/v1/stream`;
+    }
     close() {
         // No persistent connections to close for HTTP client
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { Request, Response, IRouter } from 'express'
 import { MayaraClient } from './mayara-client'
 import { createRadarProvider } from './radar-provider'
 import { SpokeForwarder } from './spoke-forwarder'
+import { NotificationForwarder } from './notification-forwarder'
 import {
   ContainerConfig,
   ContainerManagerApi,
@@ -53,6 +54,10 @@ module.exports = function (app: MayaraServerAPI): Plugin {
   let client: MayaraClient | null = null
   let currentSettings: Partial<Config> | null = null
   const spokeForwarders = new Map<string, SpokeForwarder>()
+  // Single instance: mayara emits notifications on the server-wide v1
+  // stream, not per-radar, so we only need one connection regardless of
+  // how many radars are discovered.
+  let notificationForwarder: NotificationForwarder | null = null
   let discoveryInterval: ReturnType<typeof setInterval> | null = null
   // Set true on stop() so the in-flight token poller exits its loop.
   let tokenPollerCancelled = false
@@ -111,6 +116,11 @@ module.exports = function (app: MayaraServerAPI): Plugin {
       }
       spokeForwarders.clear()
       knownRadars.clear()
+
+      if (notificationForwarder) {
+        notificationForwarder.stop()
+        notificationForwarder = null
+      }
 
       if (client) {
         client.close()
@@ -173,6 +183,9 @@ module.exports = function (app: MayaraServerAPI): Plugin {
             radarId: id,
             connected: spokeForwarders.get(id)?.isConnected() ?? false
           })),
+          notificationForwarder: {
+            connected: notificationForwarder?.isConnected() ?? false
+          },
           container: {
             state: containerState,
             image: containerImage,
@@ -634,6 +647,20 @@ module.exports = function (app: MayaraServerAPI): Plugin {
           await new Promise<void>((resolve) => setTimeout(resolve, 1000))
         }
       }
+    }
+
+    // Bring up the notification forwarder before discovery so the very
+    // first guard-zone alarm a radar fires reaches the upstream Signal
+    // K server. The forwarder owns its own reconnect loop, so failing
+    // here just means it'll reach mayara on a later attempt.
+    if (!notificationForwarder) {
+      notificationForwarder = new NotificationForwarder(app, {
+        pluginId: PLUGIN_ID,
+        url: client.getStateStreamUrl(),
+        debug: app.debug.bind(app),
+        reconnectInterval: (settings.reconnectInterval || 5) * 1000
+      })
+      notificationForwarder.start()
     }
 
     await connectAndDiscover(settings)

--- a/src/mayara-client.ts
+++ b/src/mayara-client.ts
@@ -120,6 +120,16 @@ export class MayaraClient {
     return `${wsProtocol}://${this.host}:${this.port}${API_BASE}/${radarId}/targets/stream`
   }
 
+  /**
+   * Signal K v1 stream — the same WebSocket the built-in GUI subscribes
+   * to. Used by NotificationForwarder to listen for `notifications.*`
+   * deltas (e.g. guard-zone alarms) and republish them upstream.
+   */
+  getStateStreamUrl(): string {
+    const wsProtocol = this.secure ? 'wss' : 'ws'
+    return `${wsProtocol}://${this.host}:${this.port}/signalk/v1/stream`
+  }
+
   close(): void {
     // No persistent connections to close for HTTP client
   }

--- a/src/notification-forwarder.ts
+++ b/src/notification-forwarder.ts
@@ -1,0 +1,255 @@
+import WebSocket from 'ws'
+import type { Delta } from '@signalk/server-api'
+
+/**
+ * Subset of the Signal K app surface this forwarder needs. We pin to the
+ * minimum so the unit tests can pass a stub without dragging in the full
+ * server-api types.
+ */
+export interface NotificationForwarderApp {
+  handleMessage(id: string, msg: Partial<Delta>): void
+  debug?(msg: string): void
+}
+
+export interface NotificationForwarderOptions {
+  /**
+   * Plugin id used when calling `app.handleMessage`. Signal K stamps
+   * the republished delta's `$source` from this; passing the same id
+   * the plugin registers with keeps all forwarded data attributed to
+   * one provider in the SK admin UI.
+   */
+  pluginId: string
+  /** ws:// URL of mayara-server's `/signalk/v1/stream` endpoint. */
+  url: string
+  /** Optional logger; defaults to a no-op. */
+  debug?: (msg: string) => void
+  reconnectInterval?: number
+  /**
+   * Constructor override used by tests; in production this is just the
+   * `ws` package's `WebSocket` class. Typed minimally to avoid pulling
+   * the full ws.d.ts surface into the public API.
+   */
+  webSocketFactory?: (url: string) => WebSocketLike
+}
+
+/**
+ * Bridges `notifications.*` deltas from mayara-server's Signal K v1
+ * stream into the host Signal K server via `app.handleMessage`. Mayara
+ * emits e.g. `notifications.radar.<key>.guardZone.<n>` on its own
+ * stream; without this forwarder, those alarms reach mayara's built-in
+ * GUI but not the SK admin notifications panel, the chart plotter, or
+ * any other SK consumer.
+ *
+ * On connect we send a `notifications.*` subscription so mayara filters
+ * appropriately. Each incoming delta is forwarded as-is — mayara has
+ * already shaped it to the SK spec (state / method / message), and the
+ * SK server stamps `$source` from `pluginId` on republish.
+ */
+export class NotificationForwarder {
+  private readonly pluginId: string
+  private readonly url: string
+  private readonly debug: (msg: string) => void
+  private readonly reconnectMs: number
+  private readonly webSocketFactory: (url: string) => WebSocketLike
+
+  private ws: WebSocketLike | null = null
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private closed = false
+  private connected = false
+  private readonly app: NotificationForwarderApp
+
+  constructor(app: NotificationForwarderApp, options: NotificationForwarderOptions) {
+    this.app = app
+    this.pluginId = options.pluginId
+    this.url = options.url
+    this.debug = options.debug ?? (() => {})
+    this.reconnectMs = options.reconnectInterval ?? 5000
+    this.webSocketFactory =
+      options.webSocketFactory ?? ((url: string): WebSocketLike => new WebSocket(url))
+  }
+
+  start(): void {
+    if (this.closed) return
+    this.connect()
+  }
+
+  private connect(): void {
+    if (this.closed) return
+
+    this.debug(`Connecting to notification stream: ${this.url}`)
+
+    try {
+      const ws = this.webSocketFactory(this.url)
+      this.ws = ws
+
+      ws.on('open', () => {
+        this.connected = true
+        this.debug('Connected to mayara notification stream')
+
+        // Tell mayara we only care about notification deltas. Using a
+        // wildcard means we pick up every radar's guard-zone alarms (and
+        // any future per-radar notification types mayara adds) without
+        // having to know radar ids up front.
+        const subscription = JSON.stringify({
+          subscribe: [{ path: 'notifications.*', policy: 'instant' }]
+        })
+        try {
+          ws.send(subscription)
+        } catch (err) {
+          this.debug(
+            `Failed to send notification subscription: ${err instanceof Error ? err.message : String(err)}`
+          )
+        }
+      })
+
+      ws.on('message', (data: WebSocket.RawData) => {
+        this.handleMessage(data)
+      })
+
+      ws.on('error', (err: Error) => {
+        this.connected = false
+        this.debug(`Notification stream error: ${err.message}`)
+      })
+
+      ws.on('close', (code: number) => {
+        this.connected = false
+        this.debug(`Notification stream closed: ${code}`)
+        if (!this.closed) {
+          this.scheduleReconnect()
+        }
+      })
+    } catch (err) {
+      this.debug(
+        `Failed to connect to notification stream: ${err instanceof Error ? err.message : String(err)}`
+      )
+      this.scheduleReconnect()
+    }
+  }
+
+  /**
+   * Parse one inbound text frame and forward every notification-pathed
+   * value entry to the host SK server. Non-text frames, non-JSON
+   * payloads, deltas with no notification entries, and the upstream
+   * "hello" handshake are all silently dropped.
+   *
+   * Exposed `protected` so the tests can inject frames without going
+   * through the real WebSocket.
+   */
+  protected handleMessage(data: WebSocket.RawData): void {
+    let text: string
+    if (typeof data === 'string') {
+      text = data
+    } else if (Buffer.isBuffer(data)) {
+      text = data.toString('utf8')
+    } else {
+      return
+    }
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(text)
+    } catch {
+      return
+    }
+
+    const delta = this.extractNotificationDelta(parsed)
+    if (!delta) return
+
+    try {
+      this.app.handleMessage(this.pluginId, delta)
+    } catch (err) {
+      this.debug(
+        `Failed to forward notification delta: ${err instanceof Error ? err.message : String(err)}`
+      )
+    }
+  }
+
+  /**
+   * Returns a copy of `parsed` containing only the notification values.
+   * Returns null if `parsed` isn't a Signal K delta, has no `updates`,
+   * or carries no `notifications.*` paths after filtering.
+   */
+  private extractNotificationDelta(parsed: unknown): Partial<Delta> | null {
+    if (!parsed || typeof parsed !== 'object') return null
+    const root = parsed as { updates?: unknown[] }
+    if (!Array.isArray(root.updates)) return null
+
+    const filteredUpdates: unknown[] = []
+    for (const update of root.updates) {
+      if (!update || typeof update !== 'object') continue
+      const values = (update as { values?: unknown[] }).values
+      if (!Array.isArray(values)) continue
+
+      const notificationValues = values.filter((v) => {
+        if (!v || typeof v !== 'object') return false
+        const path = (v as { path?: unknown }).path
+        return typeof path === 'string' && path.startsWith('notifications.')
+      })
+
+      if (notificationValues.length > 0) {
+        // Preserve $source / timestamp from upstream; the SK server
+        // will overlay `$source = <pluginId>` on its own, but the
+        // upstream timestamp is the moment the alarm fired and is
+        // worth keeping.
+        filteredUpdates.push({
+          ...update,
+          values: notificationValues
+        })
+      }
+    }
+
+    if (filteredUpdates.length === 0) return null
+    return { updates: filteredUpdates as Delta['updates'] }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.closed || this.reconnectTimer) return
+
+    this.debug(`Scheduling notification stream reconnect in ${this.reconnectMs}ms`)
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null
+      if (!this.closed) {
+        this.connect()
+      }
+    }, this.reconnectMs)
+  }
+
+  isConnected(): boolean {
+    return this.connected
+  }
+
+  stop(): void {
+    this.closed = true
+
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
+
+    if (this.ws) {
+      try {
+        this.ws.close()
+      } catch {
+        // Ignore close errors
+      }
+      this.ws = null
+    }
+
+    this.connected = false
+    this.debug('Stopped notification forwarder')
+  }
+}
+
+/**
+ * Minimum WebSocket surface this module touches. Lets tests inject a
+ * stub without importing the full `ws` type tree.
+ */
+export interface WebSocketLike {
+  on(event: 'open', listener: () => void): void
+  on(event: 'message', listener: (data: WebSocket.RawData) => void): void
+  on(event: 'error', listener: (err: Error) => void): void
+  on(event: 'close', listener: (code: number) => void): void
+  send(data: string): void
+  close(): void
+}

--- a/test/notification-forwarder.test.ts
+++ b/test/notification-forwarder.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { NotificationForwarder } from '../src/notification-forwarder'
+import http from 'http'
+import { WebSocketServer, WebSocket } from 'ws'
+
+let server: http.Server | null = null
+let wss: WebSocketServer | null = null
+
+afterEach(() => {
+  wss?.close()
+  server?.close()
+  wss = null
+  server = null
+})
+
+function createWsServer(): Promise<number> {
+  return new Promise((resolve) => {
+    server = http.createServer()
+    wss = new WebSocketServer({ server })
+    const s = server
+    s.listen(0, () => {
+      resolve((s.address() as { port: number }).port)
+    })
+  })
+}
+
+function makeApp() {
+  return {
+    handleMessage: vi.fn(),
+    debug: vi.fn()
+  }
+}
+
+describe('NotificationForwarder', () => {
+  it('subscribes to notifications.* on connect', async () => {
+    const port = await createWsServer()
+    const app = makeApp()
+
+    const subscriptionReceived = new Promise<string>((resolve) => {
+      wss?.on('connection', (ws: WebSocket) => {
+        ws.on('message', (data: WebSocket.RawData) => {
+          const buf = Buffer.isBuffer(data) ? data : Buffer.from(data as ArrayBuffer)
+          resolve(buf.toString('utf8'))
+        })
+      })
+    })
+
+    const forwarder = new NotificationForwarder(app, {
+      pluginId: 'test-plugin',
+      url: `ws://localhost:${port}`,
+      reconnectInterval: 100
+    })
+    forwarder.start()
+
+    const msg = await subscriptionReceived
+    const parsed = JSON.parse(msg) as { subscribe: Array<{ path: string; policy: string }> }
+    expect(parsed.subscribe).toEqual([{ path: 'notifications.*', policy: 'instant' }])
+
+    forwarder.stop()
+  })
+
+  it('forwards notification deltas via handleMessage', async () => {
+    const port = await createWsServer()
+    const app = makeApp()
+
+    const clientConnected = new Promise<WebSocket>((resolve) => {
+      wss?.on('connection', resolve)
+    })
+
+    const forwarder = new NotificationForwarder(app, {
+      pluginId: 'test-plugin',
+      url: `ws://localhost:${port}`,
+      reconnectInterval: 100
+    })
+    forwarder.start()
+
+    const ws = await clientConnected
+    // Drain the subscription send.
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    const delta = {
+      updates: [
+        {
+          $source: 'mayara',
+          timestamp: '2026-05-26T00:00:00Z',
+          values: [
+            {
+              path: 'notifications.radar.fur6424A.guardZone.1',
+              value: {
+                state: 'alert',
+                method: ['visual', 'sound'],
+                message: 'Radar fur6424A guard zone 1: target acquired'
+              }
+            }
+          ]
+        }
+      ]
+    }
+    ws.send(JSON.stringify(delta))
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(app.handleMessage).toHaveBeenCalledTimes(1)
+    const [pluginId, forwarded] = app.handleMessage.mock.calls[0] as [string, typeof delta]
+    expect(pluginId).toBe('test-plugin')
+    expect(forwarded.updates).toHaveLength(1)
+    expect(forwarded.updates[0].values).toHaveLength(1)
+    expect(forwarded.updates[0].values[0].path).toBe('notifications.radar.fur6424A.guardZone.1')
+
+    forwarder.stop()
+  })
+
+  it('drops non-notification paths within a delta', async () => {
+    const port = await createWsServer()
+    const app = makeApp()
+
+    const clientConnected = new Promise<WebSocket>((resolve) => {
+      wss?.on('connection', resolve)
+    })
+
+    const forwarder = new NotificationForwarder(app, {
+      pluginId: 'test-plugin',
+      url: `ws://localhost:${port}`,
+      reconnectInterval: 100
+    })
+    forwarder.start()
+
+    const ws = await clientConnected
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    // A mixed-path delta — only the notification value should survive.
+    ws.send(
+      JSON.stringify({
+        updates: [
+          {
+            values: [
+              { path: 'navigation.headingTrue', value: 1.2 },
+              {
+                path: 'notifications.radar.r1.guardZone.1',
+                value: { state: 'alert', method: ['visual'], message: 'x' }
+              }
+            ]
+          }
+        ]
+      })
+    )
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(app.handleMessage).toHaveBeenCalledTimes(1)
+    const forwarded = app.handleMessage.mock.calls[0][1] as {
+      updates: { values: { path: string }[] }[]
+    }
+    expect(forwarded.updates[0].values).toHaveLength(1)
+    expect(forwarded.updates[0].values[0].path).toBe('notifications.radar.r1.guardZone.1')
+  })
+
+  it('ignores deltas that carry no notification paths', async () => {
+    const port = await createWsServer()
+    const app = makeApp()
+
+    const clientConnected = new Promise<WebSocket>((resolve) => {
+      wss?.on('connection', resolve)
+    })
+
+    const forwarder = new NotificationForwarder(app, {
+      pluginId: 'test-plugin',
+      url: `ws://localhost:${port}`,
+      reconnectInterval: 100
+    })
+    forwarder.start()
+
+    const ws = await clientConnected
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    ws.send(
+      JSON.stringify({
+        updates: [{ values: [{ path: 'navigation.headingTrue', value: 1.2 }] }]
+      })
+    )
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(app.handleMessage).not.toHaveBeenCalled()
+
+    forwarder.stop()
+  })
+
+  it('ignores hello / non-delta messages', async () => {
+    const port = await createWsServer()
+    const app = makeApp()
+
+    const clientConnected = new Promise<WebSocket>((resolve) => {
+      wss?.on('connection', resolve)
+    })
+
+    const forwarder = new NotificationForwarder(app, {
+      pluginId: 'test-plugin',
+      url: `ws://localhost:${port}`,
+      reconnectInterval: 100
+    })
+    forwarder.start()
+
+    const ws = await clientConnected
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    // Mayara's hello frame and stray garbage must not throw.
+    ws.send(JSON.stringify({ name: 'mayara', version: '3.5.3' }))
+    ws.send('not json at all')
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    expect(app.handleMessage).not.toHaveBeenCalled()
+
+    forwarder.stop()
+  })
+
+  it('stop prevents reconnection', async () => {
+    vi.useFakeTimers()
+    try {
+      const app = makeApp()
+      const forwarder = new NotificationForwarder(app, {
+        pluginId: 'test-plugin',
+        url: 'ws://localhost:1',
+        reconnectInterval: 50
+      })
+
+      forwarder.start()
+      forwarder.stop()
+
+      expect(forwarder.isConnected()).toBe(false)
+
+      // Advance well past the reconnect window to prove stop() cleared
+      // the scheduled timer and the forwarder didn't reopen.
+      await vi.advanceTimersByTimeAsync(200)
+      expect(forwarder.isConnected()).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('reports connected status', async () => {
+    const port = await createWsServer()
+    const app = makeApp()
+
+    const clientConnected = new Promise<void>((resolve) => {
+      wss?.on('connection', () => {
+        resolve()
+      })
+    })
+
+    const forwarder = new NotificationForwarder(app, {
+      pluginId: 'test-plugin',
+      url: `ws://localhost:${port}`
+    })
+    expect(forwarder.isConnected()).toBe(false)
+
+    forwarder.start()
+    await clientConnected
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(forwarder.isConnected()).toBe(true)
+
+    forwarder.stop()
+    expect(forwarder.isConnected()).toBe(false)
+  })
+})


### PR DESCRIPTION
## Why

mayara already emits `notifications.radar.<key>.guardZone.<n>` on its own Signal K v1 stream (mayara-server PRs #260 + #262), but those alarms previously only reached mayara's built-in GUI. The host Signal K server, the chart plotter, and any other SK consumer saw nothing.

Closes the loop on MarineYachtRadar/mayara-server#69.

## How

`NotificationForwarder` opens one WebSocket to mayara's `/signalk/v1/stream`, subscribes to `notifications.*`, and republishes every notification-pathed value via `app.handleMessage(PLUGIN_ID, ...)`. Mixed-path deltas are filtered down to their notification entries so non-notification chatter (navigation, etc.) doesn't get accidentally forwarded. Non-JSON frames and the upstream hello handshake are silently dropped.

A single instance covers all radars — mayara's notifications stream is server-wide, not per-radar. The forwarder owns its own reconnect loop with the same 5 s default the spoke forwarders use, and surfaces in `/status` as `notificationForwarder: { connected }`.

## Tested

- 7 new unit tests against a real `ws` server: subscription payload, normal forwarding, mixed-path filtering, non-notification deltas, hello / garbage frames, stop-prevents-reconnect (fake timers), connection status.
- `npm run lint` clean.
- `npm run build` clean.
- `npm run test` 72 tests pass (was 65 + 7 new).
- `cr review --plain` against main — 1 trivial nitpick (fake timers for reconnect test) addressed before push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Introduces a `NotificationForwarder` to subscribe to mayara-server's `notifications.*` stream and forward guard-zone alarm deltas to the host Signal K server, making mayara-emitted notifications visible to Signal K consumers and the GUI.

## Changes

### New NotificationForwarder class (`src/notification-forwarder.ts`)

Implements a WebSocket client that:
- Connects to mayara's `/signalk/v1/stream` endpoint  
- Subscribes to `notifications.*` using Signal K subscription protocol
- Receives incoming deltas and filters to only forward notification-path value entries
- Forwards matched deltas to the Signal K server via `app.handleMessage(pluginId, delta)`
- Ignores non-JSON frames, the upstream hello handshake, and deltas with no notification paths
- Manages an automatic reconnection loop (5 s default interval, configurable)
- Provides `start()`, `stop()`, and `isConnected()` lifecycle methods
- Supports dependency injection of WebSocket factory and debug logging for testing

### Integration into plugin (`src/index.ts`)

- Creates a singleton `NotificationForwarder` instance at startup
- Initializes and starts the forwarder before radar discovery so notifications are delivered immediately
- Stops the forwarder during plugin shutdown
- Exposes forwarder connection status at `/status` endpoint as `notificationForwarder: { connected }`

### MayaraClient utility (`src/mayara-client.ts`)

- Adds `getStateStreamUrl()` method to construct the Signal K v1 WebSocket URL for the built-in GUI's stream, automatically selecting `wss://` or `ws://` based on the client's `secure` option

## Testing

Adds 7 new integration tests against a real WebSocket server covering:
- Subscription payload format
- Normal delta forwarding
- Mixed-path filtering (notification + non-notification entries)
- Handling of deltas without notification paths
- Ignoring non-delta and malformed frames
- Reconnection prevention after `stop()` (using fake timers)
- Connection status transitions

Test suite now includes 72 tests (previously 65).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server-signalk-plugin/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->