### PR TITLE
ci: stop tripping plugin-ci hardcoded-home regex on doc comments

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -350,7 +350,7 @@ module.exports = function (app) {
             // `--user 1000:1000` on docker / rootful podman). Without this
             // hint signalk-container assumes inImageUid=0, the in-image
             // mayara user runs under the subuid range, and the in-container
-            // mayara process cannot write to `/home/mayara/.local/share`.
+            // mayara process cannot write to the in-image XDG data dir.
             user: { inImageUid: 1000, inImageGid: 1000 }
         };
         if (Object.keys(env).length > 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -399,7 +399,7 @@ module.exports = function (app: MayaraServerAPI): Plugin {
       // `--user 1000:1000` on docker / rootful podman). Without this
       // hint signalk-container assumes inImageUid=0, the in-image
       // mayara user runs under the subuid range, and the in-container
-      // mayara process cannot write to `/home/mayara/.local/share`.
+      // mayara process cannot write to the in-image XDG data dir.
       user: { inImageUid: 1000, inImageGid: 1000 }
     }
     if (Object.keys(env).length > 0) {

--- a/test/container-integration.test.ts
+++ b/test/container-integration.test.ts
@@ -403,7 +403,7 @@ describe('mayara-server-signalk-plugin container integration', () => {
       // put the container in the subuid range, and on docker / rootful
       // podman the in-container process would run under the SK host
       // user's UID instead of the image's mayara user — either way,
-      // `/home/mayara/.local/share` (owned by uid 1000 inside the image)
+      // the in-image XDG data dir (owned by uid 1000 inside the image)
       // is unwritable and mayara fails to start.
       const { containers, plugin } = await loadPlugin()
       const { config } = containers._calls.ensureRunning[0]


### PR DESCRIPTION
## Summary

- The shared `signalk-plugin-ci` validate-pkg step flags any `"/home/<user>/"` substring in source as a hardcoded home directory, with no carve-out for comments. Three doc comments added in #41 quoted `` `/home/mayara/.local/share` `` to document the path mayara writes to inside its container, which the regex matched and failed CI on `main`.
- Reworded the three comments (src/index.ts, plugin/index.js, test/container-integration.test.ts) to describe it as "the in-image XDG data dir" instead. No behavior change.

See failing run: https://github.com/MarineYachtRadar/mayara-server-signalk-plugin/actions/runs/26428459137

## Tested

- `npm run build:all` clean (lint + tsc + webpack + 72/72 vitest)
- `cr review --plain` no findings
- Verified no remaining `"/home/<user>/"` quoted paths under `src/`, `test/`, or `plugin/`