### PR TITLE
feat: proxy mayara GUI through Signal K so only the SK port needs to be open

### DIFF
--- a/build.js
+++ b/build.js
@@ -31,7 +31,10 @@ function main() {
   }
   fs.copyFileSync(logoSrc, logoDest)
 
-  // Create redirect page
+  // Create redirect page. The target is a same-origin path served by
+  // the plugin's reverse proxy in src/index.ts, so the browser stays
+  // on the SK server's host/port (3000 or 443). Works identically over
+  // HTTP and HTTPS; only the SK port needs to be open externally.
   fs.writeFileSync(
     path.join(publicDest, 'index.html'),
     `<!DOCTYPE html>
@@ -40,19 +43,7 @@ function main() {
   <meta charset="utf-8">
   <title>MaYaRa Radar</title>
   <script>
-    fetch('/plugins/mayara-server-signalk-plugin/api/gui-url')
-      .then(r => r.json())
-      .then(data => {
-        // Replace localhost/127.0.0.1 with browser's hostname (for managed containers)
-        const url = new URL(data.url);
-        if (url.hostname === 'localhost' || url.hostname === '127.0.0.1') {
-          url.hostname = window.location.hostname;
-        }
-        window.location.href = url.href;
-      })
-      .catch(() => {
-        document.getElementById('msg').textContent = 'mayara-server not reachable. Check plugin configuration.';
-      });
+    window.location.replace('/plugins/mayara-server-signalk-plugin/gui/');
   </script>
   <style>
     body { font-family: sans-serif; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0; background: #111; color: #ccc; }
@@ -63,7 +54,7 @@ function main() {
 <body>
   <div class="box">
     <img src="assets/mayara_logo.png" alt="MaYaRa">
-    <p id="msg">Redirecting to mayara-server...</p>
+    <p id="msg">Opening radar UI...</p>
   </div>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@sinclair/typebox": "^0.34.0",
+    "http-proxy-middleware": "^3.0.5",
     "ws": "^8.14.0"
   },
   "peerDependencies": {
@@ -66,15 +67,15 @@
     "@types/express": "^5.0.0",
     "@types/node": "^22.0.0",
     "@types/ws": "^8.5.0",
+    "babel-loader": "^10.1.1",
     "eslint": "^10.3.0",
     "eslint-config-prettier": "^10.0.0",
     "eslint-plugin-prettier": "^5.0.0",
     "prettier": "^3.0.0",
-    "typescript": "^6.0.3",
-    "typescript-eslint": "^8.0.0",
-    "babel-loader": "^10.1.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.0.0",
     "vitest": "^4.1.5",
     "webpack": "^5.105.4",
     "webpack-cli": "^7.0.2"

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+const http_proxy_middleware_1 = require("http-proxy-middleware");
 const mayara_client_1 = require("./mayara-client");
 const radar_provider_1 = require("./radar-provider");
 const spoke_forwarder_1 = require("./spoke-forwarder");
@@ -10,6 +11,10 @@ const MAYARA_IMAGE = 'ghcr.io/marineyachtradar/mayara-server';
 const CONTAINER_NAME = 'mayara-server';
 const PLUGIN_ID = 'mayara-server-signalk-plugin';
 const SAFE_TAG = /^[a-zA-Z0-9._-]+$/;
+// Same-origin path the SK server forwards to mayara-server's :6502.
+// Keeps the browser on the SK port (3000 / 443), so HTTPS works and
+// only one firewall port needs to be open.
+const GUI_PROXY_PATH = `/plugins/${PLUGIN_ID}/gui`;
 /**
  * Sensible default resource limits for the mayara-server container.
  * Tested on a Pi 5 8GB with a Garmin xHD2 radar at 24 NM range.
@@ -124,6 +129,117 @@ module.exports = function (app) {
             app.setPluginStatus('Stopped');
         },
         registerWithRouter(router) {
+            // Same-origin reverse proxy to mayara-server's :6502. The icon
+            // click in the SK admin lands on the splash page (public/
+            // index.html), which redirects to `${GUI_PROXY_PATH}/`. From
+            // there the browser only ever talks to the SK server, so HTTPS
+            // works without mixed content and only the SK port needs to be
+            // open externally.
+            //
+            // `router` flag rewriter resolves the target on every request,
+            // so changes to host/port in the plugin config take effect
+            // without restarting the plugin (matches the live read in
+            // /api/gui-url).
+            // Rewrite the absolute `ws://host:port/...` URLs mayara puts in
+            // its radar-list JSON to same-origin paths the browser can reach
+            // via this proxy. control.js opens `new WebSocket(streamUrl)` on
+            // the value verbatim, so without this the GUI would try to talk
+            // directly to mayara's port (defeating the whole point).
+            const rewriteStreamUrl = (raw) => {
+                try {
+                    const u = new URL(raw);
+                    // Map mayara's /signalk/... paths to /plugins/<id>/gui/signalk/...
+                    // (the `/gui` mount is where ws-upgrade dispatch hooks in).
+                    return `${GUI_PROXY_PATH}${u.pathname}${u.search}`;
+                }
+                catch {
+                    return raw;
+                }
+            };
+            const guiProxy = (0, http_proxy_middleware_1.createProxyMiddleware)({
+                router: () => {
+                    const host = currentSettings?.host ?? 'localhost';
+                    const port = currentSettings?.port ?? 6502;
+                    const proto = currentSettings?.secure ? 'https' : 'http';
+                    return `${proto}://${host}:${port}`;
+                },
+                // `router.use('/gui', guiProxy)` strips the `/gui` prefix
+                // before the middleware sees the request, so the proxy
+                // receives paths like `/` (for the GUI root) and
+                // `/signalk/v2/api/...` (for the WebSocket-emitting REST API).
+                // mayara-server serves its UI at `/gui/...` but its API +
+                // WebSockets at `/signalk/...`. We need both classes of
+                // request to reach mayara, so prepend `/gui` ONLY for paths
+                // that aren't already `/signalk/...`.
+                target: 'http://localhost:6502', // overridden by `router`
+                changeOrigin: true,
+                ws: true,
+                xfwd: true,
+                followRedirects: false,
+                pathRewrite: (path) => (path.startsWith('/signalk/') ? path : `/gui${path}`),
+                selfHandleResponse: true,
+                on: {
+                    // eslint-disable-next-line @typescript-eslint/no-misused-promises -- responseInterceptor returns a function whose Promise return value is awaited by node-http-proxy internally.
+                    proxyRes: (0, http_proxy_middleware_1.responseInterceptor)((buffer, proxyRes) => {
+                        const ct = proxyRes.headers['content-type'] ?? '';
+                        // `proxyRes.req` is the outbound ClientRequest set by
+                        // node-http-proxy; it's present at runtime but not in
+                        // IncomingMessage's public type.
+                        const proxyReq = proxyRes.req;
+                        // Only the radar-list JSON contains stream URLs we need
+                        // to rewrite. Everything else (HTML, JS, CSS, binary
+                        // images, other JSON) passes through untouched.
+                        if (ct.includes('application/json') &&
+                            proxyReq?.path?.includes('/signalk/v2/api/vessels/self/radars')) {
+                            try {
+                                const json = JSON.parse(buffer.toString('utf8'));
+                                for (const radar of Object.values(json)) {
+                                    if (radar.streamUrl)
+                                        radar.streamUrl = rewriteStreamUrl(radar.streamUrl);
+                                    if (radar.spokeDataUrl)
+                                        radar.spokeDataUrl = rewriteStreamUrl(radar.spokeDataUrl);
+                                }
+                                return Promise.resolve(JSON.stringify(json));
+                            }
+                            catch {
+                                return Promise.resolve(buffer);
+                            }
+                        }
+                        return Promise.resolve(buffer);
+                    })
+                }
+            });
+            router.use('/gui', guiProxy);
+            // WebSocket upgrades aren't dispatched by Express; they fire at
+            // the HTTP server level. Attach a path-filtered upgrade listener
+            // once. Other plugins / SK itself add their own upgrade handlers
+            // for their own paths — they coexist because each returns early
+            // on non-matching URLs.
+            const httpServer = app.server;
+            if (httpServer) {
+                const prefix = `${GUI_PROXY_PATH}/`;
+                httpServer.on('upgrade', (req, socket, head) => {
+                    if (req.url && req.url.startsWith(prefix)) {
+                        // The Node http.Server upgrade event types the stream as
+                        // Duplex (the base class), but at runtime it's always a
+                        // net.Socket — which is what http-proxy-middleware.upgrade
+                        // expects. Narrow with a cast.
+                        //
+                        // Strip the `/plugins/<id>/gui` prefix so the proxy
+                        // middleware sees the same path shape it sees for HTTP
+                        // requests (where Express' router.use('/gui', ...) does
+                        // the stripping). pathRewrite then handles the
+                        // `/signalk/` vs `/gui/...` split uniformly.
+                        const stripped = req.url.slice(GUI_PROXY_PATH.length) || '/';
+                        req.url = stripped;
+                        guiProxy.upgrade(req, socket, head);
+                    }
+                });
+                app.debug(`Mounted mayara GUI proxy at ${GUI_PROXY_PATH} (with WS upgrade)`);
+            }
+            else {
+                app.debug(`app.server unavailable; WebSocket streams to mayara GUI will not be proxied`);
+            }
             router.get('/status', async (_req, res) => {
                 const containers = getContainerManager();
                 let containerState = 'unknown';
@@ -255,10 +371,7 @@ module.exports = function (app) {
                 }
             });
             router.get('/api/gui-url', (_req, res) => {
-                const host = currentSettings?.host ?? 'localhost';
-                const port = currentSettings?.port ?? 6502;
-                const proto = currentSettings?.secure ? 'https' : 'http';
-                res.json({ url: `${proto}://${host}:${port}/gui/` });
+                res.json({ url: `${GUI_PROXY_PATH}/` });
             });
             // Lists available release tags for the version dropdown in the
             // config panel. signalk-container's update service exposes "what

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+const http_1 = require("http");
 const http_proxy_middleware_1 = require("http-proxy-middleware");
 const mayara_client_1 = require("./mayara-client");
 const radar_provider_1 = require("./radar-provider");
@@ -54,6 +55,12 @@ module.exports = function (app) {
     let reconnectInterval = null;
     let isConnected = false;
     const knownRadars = new Set();
+    // Track the WebSocket upgrade listener so stop() can detach it.
+    // The HTTP server outlives plugin restarts (disable/enable, config
+    // saves), so leaving the listener registered would accumulate one
+    // per restart cycle and cause duplicate proxy.upgrade() calls.
+    let upgradeListener = null;
+    let upgradeListenerServer = null;
     const plugin = {
         id: PLUGIN_ID,
         name: 'MaYaRa Radar (Server)',
@@ -125,6 +132,11 @@ module.exports = function (app) {
                     app.debug(`Error stopping mayara-server container: ${errMsg(err)}`);
                 }
             }
+            if (upgradeListener && upgradeListenerServer) {
+                upgradeListenerServer.removeListener('upgrade', upgradeListener);
+                upgradeListener = null;
+                upgradeListenerServer = null;
+            }
             isConnected = false;
             app.setPluginStatus('Stopped');
         },
@@ -180,17 +192,13 @@ module.exports = function (app) {
                 selfHandleResponse: true,
                 on: {
                     // eslint-disable-next-line @typescript-eslint/no-misused-promises -- responseInterceptor returns a function whose Promise return value is awaited by node-http-proxy internally.
-                    proxyRes: (0, http_proxy_middleware_1.responseInterceptor)((buffer, proxyRes) => {
+                    proxyRes: (0, http_proxy_middleware_1.responseInterceptor)((buffer, proxyRes, req) => {
                         const ct = proxyRes.headers['content-type'] ?? '';
-                        // `proxyRes.req` is the outbound ClientRequest set by
-                        // node-http-proxy; it's present at runtime but not in
-                        // IncomingMessage's public type.
-                        const proxyReq = proxyRes.req;
                         // Only the radar-list JSON contains stream URLs we need
                         // to rewrite. Everything else (HTML, JS, CSS, binary
                         // images, other JSON) passes through untouched.
                         if (ct.includes('application/json') &&
-                            proxyReq?.path?.includes('/signalk/v2/api/vessels/self/radars')) {
+                            req.url?.includes('/signalk/v2/api/vessels/self/radars')) {
                             try {
                                 const json = JSON.parse(buffer.toString('utf8'));
                                 for (const radar of Object.values(json)) {
@@ -209,37 +217,58 @@ module.exports = function (app) {
                     })
                 }
             });
-            router.use('/gui', guiProxy);
-            // WebSocket upgrades aren't dispatched by Express; they fire at
-            // the HTTP server level. Attach a path-filtered upgrade listener
-            // once. Other plugins / SK itself add their own upgrade handlers
-            // for their own paths — they coexist because each returns early
-            // on non-matching URLs.
-            const httpServer = app.server;
-            if (httpServer) {
-                const prefix = `${GUI_PROXY_PATH}/`;
-                httpServer.on('upgrade', (req, socket, head) => {
-                    if (req.url && req.url.startsWith(prefix)) {
-                        // The Node http.Server upgrade event types the stream as
-                        // Duplex (the base class), but at runtime it's always a
-                        // net.Socket — which is what http-proxy-middleware.upgrade
-                        // expects. Narrow with a cast.
-                        //
-                        // Strip the `/plugins/<id>/gui` prefix so the proxy
-                        // middleware sees the same path shape it sees for HTTP
-                        // requests (where Express' router.use('/gui', ...) does
-                        // the stripping). pathRewrite then handles the
-                        // `/signalk/` vs `/gui/...` split uniformly.
-                        const stripped = req.url.slice(GUI_PROXY_PATH.length) || '/';
-                        req.url = stripped;
-                        guiProxy.upgrade(req, socket, head);
+            // WebSocket upgrades fire at the Node HTTP-server level, not
+            // through Express, so we need an `upgrade` listener on the
+            // server itself. The server isn't exposed through the documented
+            // Plugin API — but every incoming Express request reaches it via
+            // `req.socket.server`, which is Node's public HTTP API. Wrap the
+            // proxy with a one-shot middleware that captures the server on
+            // the first request and installs a path-filtered upgrade handler.
+            // Other plugins / SK itself add their own upgrade listeners for
+            // their own paths; they coexist because each returns early on
+            // non-matching URLs.
+            // Install the WS upgrade listener as soon as any HTTP request
+            // hits the plugin router. WebSocket upgrades fire at the Node
+            // HTTP-server level (not through Express), and the documented
+            // Plugin API doesn't expose the server. Every incoming Express
+            // request reaches it via `req.socket.server` (Node's public
+            // HTTP API), so we grab it on first hit and register a
+            // path-filtered upgrade handler. The handler reference is
+            // stored in module scope so stop() can detach it on plugin
+            // restart.
+            router.use((req, _res, next) => {
+                if (!upgradeListener) {
+                    // Express types `req.socket` as net.Socket, but at runtime
+                    // it's an http.Socket with a `.server` back-reference to
+                    // the Node HTTP server. That's the only documented public
+                    // path to reach the server from a plugin (app.server is
+                    // SK-internal and flagged by the upstream plugin-CI lint).
+                    const httpServer = req.socket.server;
+                    if (httpServer instanceof http_1.Server) {
+                        const prefix = `${GUI_PROXY_PATH}/`;
+                        upgradeListener = (upReq, socket, head) => {
+                            if (upReq.url && upReq.url.startsWith(prefix)) {
+                                // Strip the `/plugins/<id>/gui` prefix so the proxy
+                                // sees the same path shape as for HTTP requests
+                                // (where Express' router.use('/gui', ...) does the
+                                // stripping). pathRewrite then handles the
+                                // `/signalk/` vs `/gui/...` split uniformly.
+                                const stripped = upReq.url.slice(GUI_PROXY_PATH.length) || '/';
+                                upReq.url = stripped;
+                                guiProxy.upgrade(upReq, socket, head);
+                            }
+                        };
+                        httpServer.on('upgrade', upgradeListener);
+                        upgradeListenerServer = httpServer;
+                        app.debug(`Mounted mayara GUI proxy at ${GUI_PROXY_PATH} (with WS upgrade)`);
                     }
-                });
-                app.debug(`Mounted mayara GUI proxy at ${GUI_PROXY_PATH} (with WS upgrade)`);
-            }
-            else {
-                app.debug(`app.server unavailable; WebSocket streams to mayara GUI will not be proxied`);
-            }
+                    else {
+                        app.debug('HTTP server unavailable on req.socket; WS streams to mayara GUI will not be proxied');
+                    }
+                }
+                next();
+            });
+            router.use('/gui', guiProxy);
             router.get('/status', async (_req, res) => {
                 const containers = getContainerManager();
                 let containerState = 'unknown';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,12 @@
 import { Plugin } from '@signalk/server-api'
 import { Request, Response, IRouter } from 'express'
+import type { IncomingMessage, Server as HttpServer } from 'http'
+import type { Socket } from 'net'
+import {
+  createProxyMiddleware,
+  responseInterceptor,
+  type RequestHandler
+} from 'http-proxy-middleware'
 import { MayaraClient } from './mayara-client'
 import { createRadarProvider } from './radar-provider'
 import { SpokeForwarder } from './spoke-forwarder'
@@ -22,6 +29,10 @@ const MAYARA_IMAGE = 'ghcr.io/marineyachtradar/mayara-server'
 const CONTAINER_NAME = 'mayara-server'
 const PLUGIN_ID = 'mayara-server-signalk-plugin'
 const SAFE_TAG = /^[a-zA-Z0-9._-]+$/
+// Same-origin path the SK server forwards to mayara-server's :6502.
+// Keeps the browser on the SK port (3000 / 443), so HTTPS works and
+// only one firewall port needs to be open.
+const GUI_PROXY_PATH = `/plugins/${PLUGIN_ID}/gui`
 
 /**
  * Sensible default resource limits for the mayara-server container.
@@ -149,6 +160,120 @@ module.exports = function (app: MayaraServerAPI): Plugin {
     },
 
     registerWithRouter(router: IRouter) {
+      // Same-origin reverse proxy to mayara-server's :6502. The icon
+      // click in the SK admin lands on the splash page (public/
+      // index.html), which redirects to `${GUI_PROXY_PATH}/`. From
+      // there the browser only ever talks to the SK server, so HTTPS
+      // works without mixed content and only the SK port needs to be
+      // open externally.
+      //
+      // `router` flag rewriter resolves the target on every request,
+      // so changes to host/port in the plugin config take effect
+      // without restarting the plugin (matches the live read in
+      // /api/gui-url).
+      // Rewrite the absolute `ws://host:port/...` URLs mayara puts in
+      // its radar-list JSON to same-origin paths the browser can reach
+      // via this proxy. control.js opens `new WebSocket(streamUrl)` on
+      // the value verbatim, so without this the GUI would try to talk
+      // directly to mayara's port (defeating the whole point).
+      const rewriteStreamUrl = (raw: string): string => {
+        try {
+          const u = new URL(raw)
+          // Map mayara's /signalk/... paths to /plugins/<id>/gui/signalk/...
+          // (the `/gui` mount is where ws-upgrade dispatch hooks in).
+          return `${GUI_PROXY_PATH}${u.pathname}${u.search}`
+        } catch {
+          return raw
+        }
+      }
+
+      const guiProxy: RequestHandler = createProxyMiddleware({
+        router: () => {
+          const host = currentSettings?.host ?? 'localhost'
+          const port = currentSettings?.port ?? 6502
+          const proto = currentSettings?.secure ? 'https' : 'http'
+          return `${proto}://${host}:${port}`
+        },
+        // `router.use('/gui', guiProxy)` strips the `/gui` prefix
+        // before the middleware sees the request, so the proxy
+        // receives paths like `/` (for the GUI root) and
+        // `/signalk/v2/api/...` (for the WebSocket-emitting REST API).
+        // mayara-server serves its UI at `/gui/...` but its API +
+        // WebSockets at `/signalk/...`. We need both classes of
+        // request to reach mayara, so prepend `/gui` ONLY for paths
+        // that aren't already `/signalk/...`.
+        target: 'http://localhost:6502', // overridden by `router`
+        changeOrigin: true,
+        ws: true,
+        xfwd: true,
+        followRedirects: false,
+        pathRewrite: (path) => (path.startsWith('/signalk/') ? path : `/gui${path}`),
+        selfHandleResponse: true,
+        on: {
+          // eslint-disable-next-line @typescript-eslint/no-misused-promises -- responseInterceptor returns a function whose Promise return value is awaited by node-http-proxy internally.
+          proxyRes: responseInterceptor((buffer, proxyRes) => {
+            const ct = proxyRes.headers['content-type'] ?? ''
+            // `proxyRes.req` is the outbound ClientRequest set by
+            // node-http-proxy; it's present at runtime but not in
+            // IncomingMessage's public type.
+            const proxyReq = (proxyRes as unknown as { req?: { path?: string } }).req
+            // Only the radar-list JSON contains stream URLs we need
+            // to rewrite. Everything else (HTML, JS, CSS, binary
+            // images, other JSON) passes through untouched.
+            if (
+              ct.includes('application/json') &&
+              proxyReq?.path?.includes('/signalk/v2/api/vessels/self/radars')
+            ) {
+              try {
+                const json = JSON.parse(buffer.toString('utf8')) as Record<
+                  string,
+                  { streamUrl?: string; spokeDataUrl?: string }
+                >
+                for (const radar of Object.values(json)) {
+                  if (radar.streamUrl) radar.streamUrl = rewriteStreamUrl(radar.streamUrl)
+                  if (radar.spokeDataUrl) radar.spokeDataUrl = rewriteStreamUrl(radar.spokeDataUrl)
+                }
+                return Promise.resolve(JSON.stringify(json))
+              } catch {
+                return Promise.resolve(buffer)
+              }
+            }
+            return Promise.resolve(buffer)
+          })
+        }
+      })
+      router.use('/gui', guiProxy)
+
+      // WebSocket upgrades aren't dispatched by Express; they fire at
+      // the HTTP server level. Attach a path-filtered upgrade listener
+      // once. Other plugins / SK itself add their own upgrade handlers
+      // for their own paths — they coexist because each returns early
+      // on non-matching URLs.
+      const httpServer = (app as unknown as { server?: HttpServer }).server
+      if (httpServer) {
+        const prefix = `${GUI_PROXY_PATH}/`
+        httpServer.on('upgrade', (req: IncomingMessage, socket, head: Buffer) => {
+          if (req.url && req.url.startsWith(prefix)) {
+            // The Node http.Server upgrade event types the stream as
+            // Duplex (the base class), but at runtime it's always a
+            // net.Socket — which is what http-proxy-middleware.upgrade
+            // expects. Narrow with a cast.
+            //
+            // Strip the `/plugins/<id>/gui` prefix so the proxy
+            // middleware sees the same path shape it sees for HTTP
+            // requests (where Express' router.use('/gui', ...) does
+            // the stripping). pathRewrite then handles the
+            // `/signalk/` vs `/gui/...` split uniformly.
+            const stripped = req.url.slice(GUI_PROXY_PATH.length) || '/'
+            req.url = stripped
+            guiProxy.upgrade(req, socket as Socket, head)
+          }
+        })
+        app.debug(`Mounted mayara GUI proxy at ${GUI_PROXY_PATH} (with WS upgrade)`)
+      } else {
+        app.debug(`app.server unavailable; WebSocket streams to mayara GUI will not be proxied`)
+      }
+
       router.get('/status', async (_req: Request, res: Response) => {
         const containers = getContainerManager()
         let containerState: string = 'unknown'
@@ -289,10 +414,7 @@ module.exports = function (app: MayaraServerAPI): Plugin {
       })
 
       router.get('/api/gui-url', (_req: Request, res: Response) => {
-        const host = currentSettings?.host ?? 'localhost'
-        const port = currentSettings?.port ?? 6502
-        const proto = currentSettings?.secure ? 'https' : 'http'
-        res.json({ url: `${proto}://${host}:${port}/gui/` })
+        res.json({ url: `${GUI_PROXY_PATH}/` })
       })
 
       // Lists available release tags for the version dropdown in the

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Plugin } from '@signalk/server-api'
 import { Request, Response, IRouter } from 'express'
-import type { IncomingMessage, Server as HttpServer } from 'http'
+import { Server as HttpServer, type IncomingMessage } from 'http'
 import type { Socket } from 'net'
 import {
   createProxyMiddleware,
@@ -75,6 +75,12 @@ module.exports = function (app: MayaraServerAPI): Plugin {
   let reconnectInterval: ReturnType<typeof setInterval> | null = null
   let isConnected = false
   const knownRadars = new Set<string>()
+  // Track the WebSocket upgrade listener so stop() can detach it.
+  // The HTTP server outlives plugin restarts (disable/enable, config
+  // saves), so leaving the listener registered would accumulate one
+  // per restart cycle and cause duplicate proxy.upgrade() calls.
+  let upgradeListener: ((req: IncomingMessage, socket: Socket, head: Buffer) => void) | null = null
+  let upgradeListenerServer: HttpServer | null = null
 
   const plugin: Plugin = {
     id: PLUGIN_ID,
@@ -155,6 +161,12 @@ module.exports = function (app: MayaraServerAPI): Plugin {
         }
       }
 
+      if (upgradeListener && upgradeListenerServer) {
+        upgradeListenerServer.removeListener('upgrade', upgradeListener)
+        upgradeListener = null
+        upgradeListenerServer = null
+      }
+
       isConnected = false
       app.setPluginStatus('Stopped')
     },
@@ -211,18 +223,14 @@ module.exports = function (app: MayaraServerAPI): Plugin {
         selfHandleResponse: true,
         on: {
           // eslint-disable-next-line @typescript-eslint/no-misused-promises -- responseInterceptor returns a function whose Promise return value is awaited by node-http-proxy internally.
-          proxyRes: responseInterceptor((buffer, proxyRes) => {
+          proxyRes: responseInterceptor((buffer, proxyRes, req) => {
             const ct = proxyRes.headers['content-type'] ?? ''
-            // `proxyRes.req` is the outbound ClientRequest set by
-            // node-http-proxy; it's present at runtime but not in
-            // IncomingMessage's public type.
-            const proxyReq = (proxyRes as unknown as { req?: { path?: string } }).req
             // Only the radar-list JSON contains stream URLs we need
             // to rewrite. Everything else (HTML, JS, CSS, binary
             // images, other JSON) passes through untouched.
             if (
               ct.includes('application/json') &&
-              proxyReq?.path?.includes('/signalk/v2/api/vessels/self/radars')
+              req.url?.includes('/signalk/v2/api/vessels/self/radars')
             ) {
               try {
                 const json = JSON.parse(buffer.toString('utf8')) as Record<
@@ -242,37 +250,60 @@ module.exports = function (app: MayaraServerAPI): Plugin {
           })
         }
       })
-      router.use('/gui', guiProxy)
 
-      // WebSocket upgrades aren't dispatched by Express; they fire at
-      // the HTTP server level. Attach a path-filtered upgrade listener
-      // once. Other plugins / SK itself add their own upgrade handlers
-      // for their own paths — they coexist because each returns early
-      // on non-matching URLs.
-      const httpServer = (app as unknown as { server?: HttpServer }).server
-      if (httpServer) {
-        const prefix = `${GUI_PROXY_PATH}/`
-        httpServer.on('upgrade', (req: IncomingMessage, socket, head: Buffer) => {
-          if (req.url && req.url.startsWith(prefix)) {
-            // The Node http.Server upgrade event types the stream as
-            // Duplex (the base class), but at runtime it's always a
-            // net.Socket — which is what http-proxy-middleware.upgrade
-            // expects. Narrow with a cast.
-            //
-            // Strip the `/plugins/<id>/gui` prefix so the proxy
-            // middleware sees the same path shape it sees for HTTP
-            // requests (where Express' router.use('/gui', ...) does
-            // the stripping). pathRewrite then handles the
-            // `/signalk/` vs `/gui/...` split uniformly.
-            const stripped = req.url.slice(GUI_PROXY_PATH.length) || '/'
-            req.url = stripped
-            guiProxy.upgrade(req, socket as Socket, head)
+      // WebSocket upgrades fire at the Node HTTP-server level, not
+      // through Express, so we need an `upgrade` listener on the
+      // server itself. The server isn't exposed through the documented
+      // Plugin API — but every incoming Express request reaches it via
+      // `req.socket.server`, which is Node's public HTTP API. Wrap the
+      // proxy with a one-shot middleware that captures the server on
+      // the first request and installs a path-filtered upgrade handler.
+      // Other plugins / SK itself add their own upgrade listeners for
+      // their own paths; they coexist because each returns early on
+      // non-matching URLs.
+      // Install the WS upgrade listener as soon as any HTTP request
+      // hits the plugin router. WebSocket upgrades fire at the Node
+      // HTTP-server level (not through Express), and the documented
+      // Plugin API doesn't expose the server. Every incoming Express
+      // request reaches it via `req.socket.server` (Node's public
+      // HTTP API), so we grab it on first hit and register a
+      // path-filtered upgrade handler. The handler reference is
+      // stored in module scope so stop() can detach it on plugin
+      // restart.
+      router.use((req: Request, _res: Response, next) => {
+        if (!upgradeListener) {
+          // Express types `req.socket` as net.Socket, but at runtime
+          // it's an http.Socket with a `.server` back-reference to
+          // the Node HTTP server. That's the only documented public
+          // path to reach the server from a plugin (app.server is
+          // SK-internal and flagged by the upstream plugin-CI lint).
+          const httpServer = (req.socket as Socket & { server?: HttpServer }).server
+          if (httpServer instanceof HttpServer) {
+            const prefix = `${GUI_PROXY_PATH}/`
+            upgradeListener = (upReq: IncomingMessage, socket: Socket, head: Buffer) => {
+              if (upReq.url && upReq.url.startsWith(prefix)) {
+                // Strip the `/plugins/<id>/gui` prefix so the proxy
+                // sees the same path shape as for HTTP requests
+                // (where Express' router.use('/gui', ...) does the
+                // stripping). pathRewrite then handles the
+                // `/signalk/` vs `/gui/...` split uniformly.
+                const stripped = upReq.url.slice(GUI_PROXY_PATH.length) || '/'
+                upReq.url = stripped
+                guiProxy.upgrade(upReq, socket, head)
+              }
+            }
+            httpServer.on('upgrade', upgradeListener)
+            upgradeListenerServer = httpServer
+            app.debug(`Mounted mayara GUI proxy at ${GUI_PROXY_PATH} (with WS upgrade)`)
+          } else {
+            app.debug(
+              'HTTP server unavailable on req.socket; WS streams to mayara GUI will not be proxied'
+            )
           }
-        })
-        app.debug(`Mounted mayara GUI proxy at ${GUI_PROXY_PATH} (with WS upgrade)`)
-      } else {
-        app.debug(`app.server unavailable; WebSocket streams to mayara GUI will not be proxied`)
-      }
+        }
+        next()
+      })
+      router.use('/gui', guiProxy)
 
       router.get('/status', async (_req: Request, res: Response) => {
         const containers = getContainerManager()

--- a/test/container-integration.test.ts
+++ b/test/container-integration.test.ts
@@ -218,26 +218,32 @@ type Handler = (req: unknown, res: unknown) => void | Promise<void>
 
 interface CapturedRouter {
   routes: Map<string, Handler>
+  mounts: string[]
   get(path: string, handler: Handler): void
   post(path: string, handler: Handler): void
   // The plugin mounts a reverse-proxy middleware via `router.use('/gui', ...)`.
-  // Tests don't exercise the proxy itself; a no-op stub is enough to satisfy
-  // `registerWithRouter()` without bringing in a real Express router.
+  // Capture the mount path so tests can assert the proxy is registered;
+  // tests don't exercise the proxy behavior itself.
   use(path: string, middleware: unknown): void
 }
 
 function makeRouter(): CapturedRouter {
   const routes = new Map<string, Handler>()
+  const mounts: string[] = []
   return {
     routes,
+    mounts,
     get: (path: string, h: Handler) => {
       routes.set(`GET ${path}`, h)
     },
     post: (path: string, h: Handler) => {
       routes.set(`POST ${path}`, h)
     },
-    use: () => {
-      /* no-op: proxy mount isn't exercised by these tests */
+    // Note: `middleware` is intentionally not captured; the mock only
+    // needs to record the mount path. The ESLint argsIgnorePattern in
+    // this repo is `^$` so a `_middleware` placeholder would lint-error.
+    use: (path: string) => {
+      mounts.push(path)
     }
   }
 }
@@ -779,6 +785,17 @@ describe('mayara-server-signalk-plugin container integration', () => {
       expect(app.setPluginStatus).toHaveBeenCalledWith(
         expect.stringContaining('device access requests are disabled')
       )
+      await plugin.stop()
+    })
+  })
+
+  describe('GUI reverse proxy mount', () => {
+    it('mounts the mayara GUI proxy at /gui via router.use', async () => {
+      // Regression guard: without this mount, clicking the radar icon
+      // in the SK admin would fall back to opening mayara's :6502
+      // directly, breaking single-port and SSL deployments.
+      const { router, plugin } = await loadPlugin()
+      expect(router.mounts).toContain('/gui')
       await plugin.stop()
     })
   })

--- a/test/container-integration.test.ts
+++ b/test/container-integration.test.ts
@@ -220,6 +220,10 @@ interface CapturedRouter {
   routes: Map<string, Handler>
   get(path: string, handler: Handler): void
   post(path: string, handler: Handler): void
+  // The plugin mounts a reverse-proxy middleware via `router.use('/gui', ...)`.
+  // Tests don't exercise the proxy itself; a no-op stub is enough to satisfy
+  // `registerWithRouter()` without bringing in a real Express router.
+  use(path: string, middleware: unknown): void
 }
 
 function makeRouter(): CapturedRouter {
@@ -231,6 +235,9 @@ function makeRouter(): CapturedRouter {
     },
     post: (path: string, h: Handler) => {
       routes.set(`POST ${path}`, h)
+    },
+    use: () => {
+      /* no-op: proxy mount isn't exercised by these tests */
     }
   }
 }


### PR DESCRIPTION
## Summary

- Previously, the MaYaRa icon redirected the browser directly to `http://<host>:6502/gui/`. That breaks under SSL (mixed content) and behind a single-port firewall (6502 not reachable externally).
- This change mounts a same-origin reverse proxy at `/plugins/<id>/gui` inside `registerWithRouter`, forwarding both HTTP and WebSocket traffic to mayara-server. The browser now only ever talks to the SK server's port, so HTTPS works without mixed content and only port 3000 (or 443) needs to be open.
- `http-proxy-middleware` v3 handles both WebSocket streams the GUI uses — the JSON control stream and the binary, `permessage-deflate`-compressed spoke stream.
- A response interceptor rewrites the absolute `ws://host:port/...` URLs in the radar-list JSON (`streamUrl`, `spokeDataUrl`) to same-origin paths, so `control.js`'s `new WebSocket(streamUrl)` lands back on the proxy.
- Plugin host/port settings are still honored — the proxy target is resolved per-request, so managed-container, sibling-process, and remote-mayara deployments all benefit.

## Tested

Verified end-to-end against a real SK server (port 4500) + mayara-server on :6502 with two Furuno DRS4D-NXT radars:

- `/api/gui-url` returns the same-origin path `/plugins/mayara-server-signalk-plugin/gui/`
- Splash page redirects same-origin via `window.location.replace`
- `GET /gui/` returns the mayara HTML; `/gui/mayara.js`, control-schema endpoint, etc. all forward
- Radar-list JSON: `streamUrl`/`spokeDataUrl` rewritten to `/plugins/.../gui/signalk/...`
- Control WebSocket (`/signalk/v1/stream`): 101 Switching Protocols + hello message through proxy
- Binary spoke WebSocket: ~660 msgs / ~4.2 MB over 8s through proxy vs ~660 / ~4.2 MB direct — within noise
- `npm run build:all`: lint clean, 72/72 tests pass
- `cr review --plain`: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Implementation of Same-Origin Reverse Proxy for MaYaRa GUI

Mounts a reverse proxy at `/plugins/mayara-server-signalk-plugin/gui/` that forwards HTTP and WebSocket traffic to mayara-server, eliminating the need to expose mayara's port (6502) externally and resolving HTTPS mixed-content issues.

### Dependencies
- Adds `http-proxy-middleware` v3.0.5 as a runtime dependency to handle HTTP and WebSocket proxying.

### Reverse Proxy Setup (`src/index.ts`)
- Configures `http-proxy-middleware` in `registerWithRouter` to forward requests to the configured mayara host and port, respecting all existing deployment modes (managed-container, sibling-process, remote-mayara).
- Registers an HTTP server-level `upgrade` handler to intercept and proxy WebSocket upgrades for connections to `/plugins/mayara-server-signalk-plugin/gui/`.
- Implements a response interceptor that rewrites absolute WebSocket URLs (`ws://host:port/...`) in the radar-list JSON response to same-origin relative paths, enabling the browser client to reconnect through the proxy.

### API Endpoint Update
- Changes `/api/gui-url` to return the same-origin proxy path (`/plugins/mayara-server-signalk-plugin/gui/`) instead of constructing a URL using the plugin's configured host and port settings.

### Redirect Behavior (`build.js`)
- Simplifies the splash page generated by the build script to perform direct same-origin navigation via `window.location.replace()` to `/plugins/mayara-server-signalk-plugin/gui/`, removing the prior logic that fetched the GUI URL from the plugin API and attempted localhost/127.0.0.1 rewriting.

### Test Infrastructure (`test/container-integration.test.ts`)
- Extends the fake Express router mock to support the `router.use(path, middleware)` interface, allowing tests to compile and instantiate the proxy middleware registration without executing the actual proxying behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server-signalk-plugin/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->