### PR TITLE
chore(release): 1.2.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "1.1.2",
+  "version": "1.2.0-beta.1",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "signalk-plugin-enabled-by-default": true,


### PR DESCRIPTION
## Summary

- Beta pre-release for field-testing the same-origin GUI reverse proxy (#43). Bumps `package.json` from 1.1.2 to 1.2.0-beta.1.
- Minor bump is the natural fit — the proxy adds new deployment-shape capability (works under SSL and behind single-port firewalls), not just a bugfix.
- The publish workflow already routes `*-beta.*` tags to `npm publish --tag beta`, so this lands under the `beta` dist-tag without touching the `latest` 1.1.2 release. The GitHub Release will be marked `prerelease: true` by the same workflow.

## Tested

- `npm run build:all`: lint clean, 73/73 tests pass.
- `publish.yml` reviewed: `-beta.*` tag path → `npm publish --tag beta --provenance --access public`.