### PR TITLE
fix(gui-proxy): forward radar WebSocket streams under the SK proxy

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const http_1 = require("http");
+const net_1 = require("net");
 const http_proxy_middleware_1 = require("http-proxy-middleware");
 const mayara_client_1 = require("./mayara-client");
 const radar_provider_1 = require("./radar-provider");
@@ -185,7 +185,15 @@ module.exports = function (app) {
                 // that aren't already `/signalk/...`.
                 target: 'http://localhost:6502', // overridden by `router`
                 changeOrigin: true,
-                ws: true,
+                // Do NOT let the middleware auto-subscribe to the server's `upgrade`
+                // event. It would see the raw `/plugins/<id>/gui/signalk/...` URL,
+                // which `pathRewrite` can't strip the mount prefix from (it only
+                // knows `/signalk/` vs not), so the upgrade reaches mayara at a bogus
+                // `/gui/...` path and 404s. The manual `upgradeListener` below strips
+                // the prefix first, then calls `guiProxy.upgrade()`. With `ws: true`
+                // that manual call is a no-op (it guards on `wsInternalSubscribed`),
+                // so the two handlers fight and the wrong one wins. Keep this false.
+                ws: false,
                 xfwd: true,
                 followRedirects: false,
                 pathRewrite: (path) => (path.startsWith('/signalk/') ? path : `/gui${path}`),
@@ -238,13 +246,17 @@ module.exports = function (app) {
             // restart.
             router.use((req, _res, next) => {
                 if (!upgradeListener) {
-                    // Express types `req.socket` as net.Socket, but at runtime
-                    // it's an http.Socket with a `.server` back-reference to
-                    // the Node HTTP server. That's the only documented public
-                    // path to reach the server from a plugin (app.server is
-                    // SK-internal and flagged by the upstream plugin-CI lint).
-                    const httpServer = req.socket.server;
-                    if (httpServer instanceof http_1.Server) {
+                    // Express types `req.socket` as net.Socket, but at runtime it has
+                    // a `.server` back-reference to the Node server. Match on
+                    // `net.Server` (the common base) rather than `http.Server`: with
+                    // SSL enabled, Signal K's listener is an `https.Server`, which
+                    // extends `tls.Server`/`net.Server` — NOT `http.Server` — so an
+                    // `instanceof http.Server` check fails and the WS upgrade listener
+                    // is never installed (streams hang under https). `app.server` is
+                    // SK-internal and flagged by the upstream plugin-CI lint, so this
+                    // back-reference is the only documented public path to the server.
+                    const wsServer = req.socket.server;
+                    if (wsServer instanceof net_1.Server) {
                         const prefix = `${GUI_PROXY_PATH}/`;
                         upgradeListener = (upReq, socket, head) => {
                             if (upReq.url && upReq.url.startsWith(prefix)) {
@@ -258,8 +270,8 @@ module.exports = function (app) {
                                 guiProxy.upgrade(upReq, socket, head);
                             }
                         };
-                        httpServer.on('upgrade', upgradeListener);
-                        upgradeListenerServer = httpServer;
+                        wsServer.on('upgrade', upgradeListener);
+                        upgradeListenerServer = wsServer;
                         app.debug(`Mounted mayara GUI proxy at ${GUI_PROXY_PATH} (with WS upgrade)`);
                     }
                     else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { Plugin } from '@signalk/server-api'
 import { Request, Response, IRouter } from 'express'
-import { Server as HttpServer, type IncomingMessage } from 'http'
-import type { Socket } from 'net'
+import { type IncomingMessage } from 'http'
+import { Server as NetServer, type Socket } from 'net'
 import {
   createProxyMiddleware,
   responseInterceptor,
@@ -80,7 +80,7 @@ module.exports = function (app: MayaraServerAPI): Plugin {
   // saves), so leaving the listener registered would accumulate one
   // per restart cycle and cause duplicate proxy.upgrade() calls.
   let upgradeListener: ((req: IncomingMessage, socket: Socket, head: Buffer) => void) | null = null
-  let upgradeListenerServer: HttpServer | null = null
+  let upgradeListenerServer: NetServer | null = null
 
   const plugin: Plugin = {
     id: PLUGIN_ID,
@@ -216,7 +216,15 @@ module.exports = function (app: MayaraServerAPI): Plugin {
         // that aren't already `/signalk/...`.
         target: 'http://localhost:6502', // overridden by `router`
         changeOrigin: true,
-        ws: true,
+        // Do NOT let the middleware auto-subscribe to the server's `upgrade`
+        // event. It would see the raw `/plugins/<id>/gui/signalk/...` URL,
+        // which `pathRewrite` can't strip the mount prefix from (it only
+        // knows `/signalk/` vs not), so the upgrade reaches mayara at a bogus
+        // `/gui/...` path and 404s. The manual `upgradeListener` below strips
+        // the prefix first, then calls `guiProxy.upgrade()`. With `ws: true`
+        // that manual call is a no-op (it guards on `wsInternalSubscribed`),
+        // so the two handlers fight and the wrong one wins. Keep this false.
+        ws: false,
         xfwd: true,
         followRedirects: false,
         pathRewrite: (path) => (path.startsWith('/signalk/') ? path : `/gui${path}`),
@@ -272,13 +280,17 @@ module.exports = function (app: MayaraServerAPI): Plugin {
       // restart.
       router.use((req: Request, _res: Response, next) => {
         if (!upgradeListener) {
-          // Express types `req.socket` as net.Socket, but at runtime
-          // it's an http.Socket with a `.server` back-reference to
-          // the Node HTTP server. That's the only documented public
-          // path to reach the server from a plugin (app.server is
-          // SK-internal and flagged by the upstream plugin-CI lint).
-          const httpServer = (req.socket as Socket & { server?: HttpServer }).server
-          if (httpServer instanceof HttpServer) {
+          // Express types `req.socket` as net.Socket, but at runtime it has
+          // a `.server` back-reference to the Node server. Match on
+          // `net.Server` (the common base) rather than `http.Server`: with
+          // SSL enabled, Signal K's listener is an `https.Server`, which
+          // extends `tls.Server`/`net.Server` — NOT `http.Server` — so an
+          // `instanceof http.Server` check fails and the WS upgrade listener
+          // is never installed (streams hang under https). `app.server` is
+          // SK-internal and flagged by the upstream plugin-CI lint, so this
+          // back-reference is the only documented public path to the server.
+          const wsServer = (req.socket as Socket & { server?: NetServer }).server
+          if (wsServer instanceof NetServer) {
             const prefix = `${GUI_PROXY_PATH}/`
             upgradeListener = (upReq: IncomingMessage, socket: Socket, head: Buffer) => {
               if (upReq.url && upReq.url.startsWith(prefix)) {
@@ -292,8 +304,8 @@ module.exports = function (app: MayaraServerAPI): Plugin {
                 guiProxy.upgrade(upReq, socket, head)
               }
             }
-            httpServer.on('upgrade', upgradeListener)
-            upgradeListenerServer = httpServer
+            wsServer.on('upgrade', upgradeListener)
+            upgradeListenerServer = wsServer
             app.debug(`Mounted mayara GUI proxy at ${GUI_PROXY_PATH} (with WS upgrade)`)
           } else {
             app.debug(


### PR DESCRIPTION
## Summary

The mayara GUI's WebSocket streams (radar state + spokes) never reached mayara when the GUI was opened through the Signal K plugin proxy, leaving the radar display stuck on "Disconnected". Two faults in the proxy's WebSocket upgrade handling:

- **HTTP-mode conflict:** `ws: true` made `http-proxy-middleware` auto-subscribe its own `upgrade` handler to the server. It saw the raw `/plugins/<id>/gui/signalk/...` URL, which `pathRewrite` can't strip the mount prefix from, so the upgrade reached mayara at a bogus `/gui/...` path and 404'd. The plugin's manual upgrade listener — which *does* strip the prefix — was a no-op while the middleware was subscribed (it guards on `wsInternalSubscribed`). Setting `ws: false` lets the manual listener actually run.

- **SSL-mode failure:** the manual listener gated on `req.socket.server instanceof http.Server`. With SSL enabled, Signal K's listener is an `https.Server`, which extends `tls.Server`/`net.Server` — **not** `http.Server` — so the check failed, the listener was never installed, and every `wss://` upgrade hung with no response. Matching on `net.Server` (the common base of both) fixes it.

Pairs with the mayara-server GUI change that makes the GUI address its API/WS relative to the proxy mount.

## Tested

- `npm run build:all` — lint, tsc + webpack build, and 73 tests pass.
- Manually verified end-to-end against a real Furuno radar through this plugin in external mode behind a local Signal K server:
  - Over `http://` and over `https://` (SSL), the state and spoke WebSockets connect (no 1006, no reconnect loop), the radar leaves standby, and the PPI paints live echoes.
  - Confirmed the SSL path specifically reproduced the hang before the `net.Server` fix and works after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Fixes two faults in the Signal K plugin proxy that prevent the mayara GUI's WebSocket streams (radar state and spokes) from reaching mayara when accessed through the plugin proxy.

## Changes

**HTTP-mode conflict resolution:**
The proxy middleware configuration changes `ws` from `true` to `false`, preventing http-proxy-middleware from auto-subscribing its own `upgrade` handler. This allows the plugin's manual upgrade listener to execute instead, which correctly rewrites the URL path by stripping the mount prefix before delegating to the GUI proxy.

**HTTPS/SSL support:**
The upgrade listener now checks against `net.Server` (the common base class for both `http.Server` and `https.Server`) instead of only `http.Server`. This enables the listener to be properly installed when Signal K runs under HTTPS with `https.Server`, fixing the previous hang when `wss://` upgrades were attempted.

**Implementation details:**
- Imports `IncomingMessage` as a type from the `http` module
- Changes the server type check in the `instanceof` validation for runtime compatibility with both HTTP and HTTPS servers
- Adjusts event wiring from `httpServer.on('upgrade', ...)` to `wsServer.on('upgrade', ...)`
- Maintains the existing URL path rewriting logic that filters requests by the `GUI_PROXY_PATH` prefix and rewrites the path before proxying

## Testing

Build and type checking pass (`npm run build:all`), all 73 tests pass. End-to-end manual verification with a Furuno radar confirms WebSocket connections and live PPI rendering function correctly over both HTTP and HTTPS protocols.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MarineYachtRadar/mayara-server-signalk-plugin/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->