### PR TITLE
fix(gui-proxy): pass the bare /signalk discovery path through to mayara

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -180,9 +180,10 @@ module.exports = function (app) {
                 // receives paths like `/` (for the GUI root) and
                 // `/signalk/v2/api/...` (for the WebSocket-emitting REST API).
                 // mayara-server serves its UI at `/gui/...` but its API +
-                // WebSockets at `/signalk/...`. We need both classes of
-                // request to reach mayara, so prepend `/gui` ONLY for paths
-                // that aren't already `/signalk/...`.
+                // WebSockets at `/signalk/...` (and the bare `/signalk`
+                // discovery endpoint the GUI probes for mode detection). We
+                // need both classes of request to reach mayara, so prepend
+                // `/gui` ONLY for paths that aren't already under `/signalk`.
                 target: 'http://localhost:6502', // overridden by `router`
                 changeOrigin: true,
                 // Do NOT let the middleware auto-subscribe to the server's `upgrade`
@@ -196,7 +197,7 @@ module.exports = function (app) {
                 ws: false,
                 xfwd: true,
                 followRedirects: false,
-                pathRewrite: (path) => (path.startsWith('/signalk/') ? path : `/gui${path}`),
+                pathRewrite: (path) => path === '/signalk' || path.startsWith('/signalk/') ? path : `/gui${path}`,
                 selfHandleResponse: true,
                 on: {
                     // eslint-disable-next-line @typescript-eslint/no-misused-promises -- responseInterceptor returns a function whose Promise return value is awaited by node-http-proxy internally.

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,9 +211,10 @@ module.exports = function (app: MayaraServerAPI): Plugin {
         // receives paths like `/` (for the GUI root) and
         // `/signalk/v2/api/...` (for the WebSocket-emitting REST API).
         // mayara-server serves its UI at `/gui/...` but its API +
-        // WebSockets at `/signalk/...`. We need both classes of
-        // request to reach mayara, so prepend `/gui` ONLY for paths
-        // that aren't already `/signalk/...`.
+        // WebSockets at `/signalk/...` (and the bare `/signalk`
+        // discovery endpoint the GUI probes for mode detection). We
+        // need both classes of request to reach mayara, so prepend
+        // `/gui` ONLY for paths that aren't already under `/signalk`.
         target: 'http://localhost:6502', // overridden by `router`
         changeOrigin: true,
         // Do NOT let the middleware auto-subscribe to the server's `upgrade`
@@ -227,7 +228,8 @@ module.exports = function (app: MayaraServerAPI): Plugin {
         ws: false,
         xfwd: true,
         followRedirects: false,
-        pathRewrite: (path) => (path.startsWith('/signalk/') ? path : `/gui${path}`),
+        pathRewrite: (path) =>
+          path === '/signalk' || path.startsWith('/signalk/') ? path : `/gui${path}`,
         selfHandleResponse: true,
         on: {
           // eslint-disable-next-line @typescript-eslint/no-misused-promises -- responseInterceptor returns a function whose Promise return value is awaited by node-http-proxy internally.


### PR DESCRIPTION
## Summary

Follow-up to #47. The GUI's mode-detection (`detectMode`) probes the bare `/signalk` endpoint (no trailing slash) to check whether it's talking to mayara. The proxy's `pathRewrite` only passed `/signalk/` through, so the bare path got `/gui` prepended and hit mayara's static file server as `/gui/signalk` → 404.

Detection still worked because it falls through to a second probe, but the first probe always failed behind the proxy and logged a misleading 404 in the console. The fix matches `/signalk` exactly in addition to the `/signalk/` prefix.

(Bare `/signalk` returns 200 on mayara directly — it's the discovery/endpoints document — so once forwarded correctly it resolves.)

## Tested

- `npm run build:all` — lint, build, and 73 tests pass.
- Confirmed against mayara directly: `GET /signalk` returns 200, so the forwarded request resolves; previously the proxied `…/gui/signalk` returned 404.