### PR TITLE
docs: document the proxied GUI and its WebSocket forwarding gotchas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,15 @@ Test guard: "declares the mayara image in-image UID/GID for correct uid mapping"
 
 `src/index.ts` passes `DEFAULT_RESOURCES` to signalk-container's `ensureRunning`. Users can field-level-override any limit via signalk-container's plugin config (`containerOverrides["mayara-server"]`). When changing defaults, also update the README table at the bottom of the "Resource Limits" section.
 
+### GUI proxy WebSocket forwarding
+
+The mayara GUI is proxied through Signal K at `/plugins/<id>/gui/` so only the SK port needs to be open. The GUI's REST calls go through Express' `router.use('/gui', guiProxy)`, but its radar/state/spoke **WebSocket** upgrades fire at the Node HTTP-server level, so `registerWithRouter` installs a manual `upgrade` listener on `req.socket.server`. Two non-obvious traps live here:
+
+- **Match the server on `net.Server`, not `http.Server`.** With SSL enabled, Signal K's listener is an `https.Server`, which extends `tls.Server`/`net.Server` — **not** `http.Server`. An `instanceof http.Server` check silently fails under HTTPS, the listener is never installed, and every `wss://` upgrade hangs (radar display stuck on "Disconnected"). HTTP works, HTTPS doesn't — a classic SSL-only regression.
+- **Keep `ws: false` on `createProxyMiddleware`.** With `ws: true`, the middleware auto-subscribes its *own* upgrade handler to the server and the manual `guiProxy.upgrade()` call becomes a no-op (it guards on `wsInternalSubscribed`). The auto-handler sees the raw `/plugins/<id>/gui/signalk/...` URL, which `pathRewrite` can't strip the mount prefix from, so the upgrade reaches mayara at a bogus `/gui/...` path and 404s. The manual listener strips the prefix first, so it must be the one that runs.
+
+`pathRewrite` passes anything under `/signalk` (including the bare `/signalk` discovery path the GUI probes for mode detection) straight through; everything else gets `/gui` prepended for the static asset server.
+
 ## Dependencies
 
 - Signal K Server ≥ 2.24.0 (Radar API requirement)

--- a/README.md
+++ b/README.md
@@ -132,7 +132,11 @@ Set **Managed container** to off to connect to a mayara-server instance running 
 
 ### Radar Display
 
-The webapp redirects to mayara-server's built-in GUI at `http://<host>:6502/gui/`.
+The webapp opens mayara-server's built-in GUI proxied through the Signal K
+server at `/plugins/mayara-server-signalk-plugin/gui/`, so only the Signal K
+port needs to be reachable — mayara-server's own port (6502) does not have to
+be exposed. The proxy forwards the GUI's REST calls and its radar/state/spoke
+WebSocket streams to mayara-server, over both HTTP and HTTPS.
 
 ## Features
 


### PR DESCRIPTION
## Summary

Documentation follow-up to the GUI-proxy fixes (#47, #48).

- **README**: the "Radar Display" section still described the pre-proxy behavior ("redirects to `:6502/gui/`"). The GUI is now served through the Signal K proxy at `/plugins/<id>/gui/`, so only the SK port needs to be reachable. Corrected, with a note that the proxy forwards both REST and the radar/state/spoke WebSocket streams over HTTP and HTTPS.
- **AGENTS.md**: added a "GUI proxy WebSocket forwarding" gotcha capturing the two non-obvious traps fixed in #47 — the upgrade-listener server must match `net.Server` (an `https.Server` is not an `http.Server`, which silently broke WS under SSL), and `createProxyMiddleware` must keep `ws: false` so the manual prefix-stripping upgrade listener runs instead of the middleware's auto-handler.

Docs only — no code changes.