### PR TITLE
chore(release): 1.2.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "1.2.0-beta.1",
+  "version": "1.2.0-beta.2",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "signalk-plugin-enabled-by-default": true,


### PR DESCRIPTION
## Summary

Pre-release `1.2.0-beta.2`. Ships the GUI-proxy fixes merged since `v1.2.0-beta.1`:

- #47 — forward the radar state/spoke WebSocket streams under the SK proxy (fixes the "Disconnected" display, including under SSL).
- #48 — pass the bare `/signalk` discovery path through to mayara (removes a spurious detectMode 404).
- #49 — docs: correct the README's GUI URL and add the WS-proxy gotchas to AGENTS.md.

Version bump only.