### PR TITLE
chore(release): 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "1.2.0-beta.2",
+  "version": "1.2.0",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "signalk-plugin-enabled-by-default": true,


### PR DESCRIPTION
## Summary

- Promote `1.2.0-beta.2` to `1.2.0` (no code changes since beta.2 merged).

## Tested

- `npm run build:all` (lint + tsc + webpack + vitest, 73/73 tests pass).