### PR TITLE
fix(gui-proxy): re-stream body-parser-consumed PUT/POST bodies to mayara

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -200,6 +200,21 @@ module.exports = function (app) {
                 pathRewrite: (path) => path === '/signalk' || path.startsWith('/signalk/') ? path : `/gui${path}`,
                 selfHandleResponse: true,
                 on: {
+                    // Signal K mounts `express.json()` before the plugin router
+                    // for its own /signalk/v1/... handlers, so by the time a
+                    // PUT/POST reaches our proxy the original request stream
+                    // has already been drained into `req.body`. http-proxy then
+                    // opens the upstream socket, copies the `Content-Length`
+                    // header from the incoming request, but has no bytes to
+                    // pipe — mayara waits for the body that never arrives and
+                    // the connection hangs until the client times out. The
+                    // visible symptom: every radar control PUT (power, gain,
+                    // range, sea, rain, …) from the GUI fails with HTTP 000
+                    // / "fetch failed", radar stays in standby. fixRequestBody
+                    // re-serializes `req.body` (when present) and writes it to
+                    // the upstream ClientRequest with a corrected Content-Length.
+                    // For GET / HEAD it's a no-op (req.body is undefined).
+                    proxyReq: http_proxy_middleware_1.fixRequestBody,
                     // eslint-disable-next-line @typescript-eslint/no-misused-promises -- responseInterceptor returns a function whose Promise return value is awaited by node-http-proxy internally.
                     proxyRes: (0, http_proxy_middleware_1.responseInterceptor)((buffer, proxyRes, req) => {
                         const ct = proxyRes.headers['content-type'] ?? '';

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { type IncomingMessage } from 'http'
 import { Server as NetServer, type Socket } from 'net'
 import {
   createProxyMiddleware,
+  fixRequestBody,
   responseInterceptor,
   type RequestHandler
 } from 'http-proxy-middleware'
@@ -232,6 +233,21 @@ module.exports = function (app: MayaraServerAPI): Plugin {
           path === '/signalk' || path.startsWith('/signalk/') ? path : `/gui${path}`,
         selfHandleResponse: true,
         on: {
+          // Signal K mounts `express.json()` before the plugin router
+          // for its own /signalk/v1/... handlers, so by the time a
+          // PUT/POST reaches our proxy the original request stream
+          // has already been drained into `req.body`. http-proxy then
+          // opens the upstream socket, copies the `Content-Length`
+          // header from the incoming request, but has no bytes to
+          // pipe — mayara waits for the body that never arrives and
+          // the connection hangs until the client times out. The
+          // visible symptom: every radar control PUT (power, gain,
+          // range, sea, rain, …) from the GUI fails with HTTP 000
+          // / "fetch failed", radar stays in standby. fixRequestBody
+          // re-serializes `req.body` (when present) and writes it to
+          // the upstream ClientRequest with a corrected Content-Length.
+          // For GET / HEAD it's a no-op (req.body is undefined).
+          proxyReq: fixRequestBody,
           // eslint-disable-next-line @typescript-eslint/no-misused-promises -- responseInterceptor returns a function whose Promise return value is awaited by node-http-proxy internally.
           proxyRes: responseInterceptor((buffer, proxyRes, req) => {
             const ct = proxyRes.headers['content-type'] ?? ''

--- a/test/container-integration.test.ts
+++ b/test/container-integration.test.ts
@@ -813,6 +813,22 @@ describe('mayara-server-signalk-plugin container integration', () => {
       expect(router.mounts).toContain('/gui')
       await plugin.stop()
     })
+
+    it('wires fixRequestBody on proxyReq to re-stream body-parser-consumed JSON', () => {
+      // SK mounts express.json() before the plugin router, which drains
+      // the request stream into req.body. Without re-streaming, every
+      // PUT/POST through the GUI proxy hangs until the client times
+      // out (HTTP 000) — the upstream socket has the right
+      // Content-Length but zero body bytes. fixRequestBody (a public
+      // export of http-proxy-middleware) re-serializes req.body and
+      // writes it to the ClientRequest. This static guard catches
+      // accidental removal — radar control PUTs would silently break
+      // and the radar would stay in standby with no obvious error.
+      const source = readFileSync(join(__dirname, '../src/index.ts'), 'utf-8')
+      expect(source).toMatch(/proxyReq:\s*fixRequestBody/)
+      expect(source).toMatch(/from\s+['"]http-proxy-middleware['"]/)
+      expect(source).toMatch(/\bfixRequestBody\b/)
+    })
   })
 
   describe('plugin.stop() lifecycle', () => {


### PR DESCRIPTION
## Summary

- Every radar control change from the GUI (power, gain, range, sea, rain, ...) sends a PUT to `/signalk/v2/api/vessels/self/radars/<id>/controls/<x>`. Through the SK proxy, each one hung until the client timed out (HTTP 000); direct PUTs to mayara on :6502 returned 200 in < 3 ms. Radar stayed in standby with no obvious error.
- Cause: Signal K mounts `express.json()` before plugin routers for its own `/signalk/v1/...` handlers. By the time the request reaches the plugin's `createProxyMiddleware`, the incoming stream has already been drained into `req.body`. `http-proxy` opens the upstream socket, copies the `Content-Length` header from the incoming request, but has zero bytes to pipe -- mayara waits for a body that never arrives.
- Wire `fixRequestBody` (a public export of `http-proxy-middleware`) as the `proxyReq` handler. It detects the drained-body case, re-serializes `req.body`, and writes it to the upstream `ClientRequest` with a corrected Content-Length. No-op for GET/HEAD (`req.body` undefined) and for requests without a Content-Type, so the existing GUI/REST path is untouched.
- Static guard in `test/container-integration.test.ts` catches accidental removal. Proxy options are not introspectable at runtime, but a regression here is severe and silent (radar stays in standby), so the assertion lives in source-text shape.

## Tested

- Reproduced before the change with 5 sequential proxied PUTs to `power` -- all 5 returned HTTP 000 after a 6 s timeout. The same 5 PUTs direct to mayara on :6502 returned HTTP 200 in < 3 ms each.
- `npm run build:all` -- lint clean, tsc + webpack build clean, vitest 75/75 (was 74, +1 for the new "wires fixRequestBody on proxyReq" assertion).
- `cr review --plain` -- no findings.