### PR TITLE
chore(release): 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "signalk-plugin-enabled-by-default": true,


### PR DESCRIPTION
## Summary

Ships two fixes since 1.2.0:

- **#52** `fix(container): auto-pull newer mayara-server image when tag is floating` — opts into signalk-container's `autoUpdateOnFloatingTag` so boats on `:latest` (or `:main`, etc.) pick up new mayara images on every plugin start instead of running stale images forever. Offline-tolerant; semver pins unaffected.
- **#53** `fix(gui-proxy): re-stream body-parser-consumed PUT/POST bodies to mayara` — wires `fixRequestBody` so every radar control change from the proxied GUI (power, gain, range, sea, rain, ...) actually reaches mayara. Without it, every PUT hung until the client timed out and the radar stayed in standby.

## Tested

- `npm run build:all` — lint clean, tsc + webpack build clean, vitest 75/75.