### PR TITLE
fix(container): derive nav-address scheme/port from live SK config

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -460,6 +460,39 @@ module.exports = function (app) {
     // Container management
     // ==========================================================================
     /**
+     * Resolve how mayara-server should reach the local Signal K server
+     * over the loopback interface: the WebSocket scheme (`ws` vs `wss`)
+     * and the port SK's own listener is bound to.
+     *
+     * The container runs with `networkMode: 'host'`, so `127.0.0.1` inside
+     * it is the host loopback — i.e. SK's own listener. We therefore want
+     * SK's *local* listener port and TLS state, not the externally
+     * advertised one (`getExternalPort()` may honor `EXTERNALPORT` or a
+     * reverse-proxy port that isn't reachable on loopback).
+     *
+     * Source of truth, in priority order:
+     *   1. The live SK runtime config (`app.config.settings`). This is the
+     *      only reliable signal — `process.env.PORT` alone is the plain-
+     *      HTTP port even on a TLS server (where the API lives on the SSL
+     *      port). The `@signalk/server-api` types don't declare `config`,
+     *      so it's an untyped, fully optional-chained read.
+     *   2. Environment fallback when config is unreadable: `SSLPORT`
+     *      implies TLS; otherwise plain HTTP on `PORT`.
+     *   3. Final fallback: plain `ws` on 3000 (the historical default).
+     *
+     * The port resolution mirrors signalk-server's own `getSslPort` /
+     * `getHttpPort` (`SSLPORT||sslport||3443` and `PORT||port||3000`).
+     */
+    function resolveSignalkLoopback() {
+        const cfg = app.config;
+        const settings = cfg?.settings;
+        const ssl = typeof settings?.ssl === 'boolean' ? settings.ssl : Boolean(process.env.SSLPORT);
+        const port = ssl
+            ? Number(process.env.SSLPORT) || Number(settings?.sslport) || 3443
+            : Number(process.env.PORT) || Number(settings?.port) || 3000;
+        return { scheme: ssl ? 'wss' : 'ws', port };
+    }
+    /**
      * Build a ContainerConfig for the mayara-server container with the
      * given tag. Used at startup, when applying updates, and after a
      * background token mint completes — signalk-container drift-detects
@@ -467,9 +500,14 @@ module.exports = function (app) {
      * transparently.
      *
      * Default nav-address is the upstream Signal K server itself:
-     *   - `ws:127.0.0.1:${SK_PORT}` plus `MAYARA_SIGNALK_TOKEN` env var
-     *     when a cached device token exists (full WS path → AIS REST
-     *     seeding works inside the container).
+     *   - `${ws|wss}:127.0.0.1:${SK_PORT}` plus `MAYARA_SIGNALK_TOKEN`
+     *     env var when a cached device token exists (full WS path → AIS
+     *     REST seeding works inside the container). The scheme and port
+     *     are derived from the live SK config (`resolveSignalkLoopback`),
+     *     not hardcoded — a TLS-enabled SK only speaks `wss:` and serves
+     *     plain HTTP as a 302→HTTPS redirect that mayara's discovery
+     *     client can't follow. `--accept-invalid-certs` is added for the
+     *     `wss:` loopback (self-signed localhost cert).
      *   - `tcp:127.0.0.1:${TCPSTREAMPORT}` otherwise (legacy delta
      *     stream; AIS overlay still works but only fills from live
      *     deltas, not the initial REST snapshot).
@@ -491,7 +529,7 @@ module.exports = function (app) {
     function buildContainerConfig(tag) {
         const userArgs = currentSettings?.mayaraArgs ?? [];
         const userOverridesNav = userArgs.some((a) => a === '-n' || a === '--navigation-address');
-        const skPort = Number(process.env.PORT) || 3000;
+        const sk = resolveSignalkLoopback();
         const tcpPort = Number(process.env.TCPSTREAMPORT) || 8375;
         const dataDir = app.getDataDirPath();
         const cachedToken = userOverridesNav ? undefined : (0, signalk_token_1.readCachedToken)(dataDir);
@@ -499,7 +537,24 @@ module.exports = function (app) {
         const env = {};
         if (!userOverridesNav) {
             if (cachedToken !== undefined) {
-                injected.push('-n', `ws:127.0.0.1:${skPort}`);
+                // Derive the scheme + port from the live Signal K server config
+                // rather than hardcoding `ws:` and `process.env.PORT`. On a
+                // TLS-enabled SK the plain-HTTP listener only 302-redirects to
+                // HTTPS, and mayara's discovery client rejects the redirect (it
+                // requires a 200 and does not follow `Location`) — so `ws:` to
+                // the HTTP port loops forever and no AIS/nav ever reaches the
+                // radar. `wss:` against the SSL port is the only path that
+                // completes discovery (the SK discovery doc advertises only
+                // `wss://` when ssl is on).
+                injected.push('-n', `${sk.scheme}:127.0.0.1:${sk.port}`);
+                // mayara refuses to start HTTPS discovery against a self-signed
+                // cert without this, and re-checks it on the WSS upgrade. The SK
+                // loopback cert is self-signed; accepting it is safe because the
+                // connection never leaves 127.0.0.1 (no MITM surface). Only
+                // injected for the secure scheme.
+                if (sk.scheme === 'wss') {
+                    injected.push('--accept-invalid-certs');
+                }
                 env.MAYARA_SIGNALK_TOKEN = cachedToken;
             }
             else {

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -470,18 +470,21 @@ module.exports = function (app) {
      * advertised one (`getExternalPort()` may honor `EXTERNALPORT` or a
      * reverse-proxy port that isn't reachable on loopback).
      *
-     * Source of truth, in priority order:
-     *   1. The live SK runtime config (`app.config.settings`). This is the
-     *      only reliable signal — `process.env.PORT` alone is the plain-
-     *      HTTP port even on a TLS server (where the API lives on the SSL
-     *      port). The `@signalk/server-api` types don't declare `config`,
-     *      so it's an untyped, fully optional-chained read.
-     *   2. Environment fallback when config is unreadable: `SSLPORT`
-     *      implies TLS; otherwise plain HTTP on `PORT`.
-     *   3. Final fallback: plain `ws` on 3000 (the historical default).
+     * TLS detection: prefer `settings.ssl` when it's an explicit boolean;
+     * otherwise infer TLS from the presence of the `SSLPORT` env var. We
+     * read `app.config.settings` because `process.env.PORT` alone is the
+     * plain-HTTP port even on a TLS server (where the API lives on the SSL
+     * port). The `@signalk/server-api` types don't declare `config`, so
+     * it's an untyped, fully optional-chained read.
      *
-     * The port resolution mirrors signalk-server's own `getSslPort` /
-     * `getHttpPort` (`SSLPORT||sslport||3443` and `PORT||port||3000`).
+     * Port resolution mirrors signalk-server's own `getSslPort` /
+     * `getHttpPort`, where the env var takes precedence over the config
+     * value:
+     *   - TLS:   `SSLPORT || settings.sslport || 3443`
+     *   - plain: `PORT    || settings.port    || 3000`
+     *
+     * With neither config nor env present this resolves to the historical
+     * default of plain `ws` on 3000.
      */
     function resolveSignalkLoopback() {
         const cfg = app.config;

--- a/src/index.ts
+++ b/src/index.ts
@@ -518,6 +518,43 @@ module.exports = function (app: MayaraServerAPI): Plugin {
   // ==========================================================================
 
   /**
+   * Resolve how mayara-server should reach the local Signal K server
+   * over the loopback interface: the WebSocket scheme (`ws` vs `wss`)
+   * and the port SK's own listener is bound to.
+   *
+   * The container runs with `networkMode: 'host'`, so `127.0.0.1` inside
+   * it is the host loopback — i.e. SK's own listener. We therefore want
+   * SK's *local* listener port and TLS state, not the externally
+   * advertised one (`getExternalPort()` may honor `EXTERNALPORT` or a
+   * reverse-proxy port that isn't reachable on loopback).
+   *
+   * Source of truth, in priority order:
+   *   1. The live SK runtime config (`app.config.settings`). This is the
+   *      only reliable signal — `process.env.PORT` alone is the plain-
+   *      HTTP port even on a TLS server (where the API lives on the SSL
+   *      port). The `@signalk/server-api` types don't declare `config`,
+   *      so it's an untyped, fully optional-chained read.
+   *   2. Environment fallback when config is unreadable: `SSLPORT`
+   *      implies TLS; otherwise plain HTTP on `PORT`.
+   *   3. Final fallback: plain `ws` on 3000 (the historical default).
+   *
+   * The port resolution mirrors signalk-server's own `getSslPort` /
+   * `getHttpPort` (`SSLPORT||sslport||3443` and `PORT||port||3000`).
+   */
+  function resolveSignalkLoopback(): { scheme: 'ws' | 'wss'; port: number } {
+    const cfg = (app as unknown as { config?: { settings?: Record<string, unknown> } }).config
+    const settings = cfg?.settings
+
+    const ssl = typeof settings?.ssl === 'boolean' ? settings.ssl : Boolean(process.env.SSLPORT)
+
+    const port = ssl
+      ? Number(process.env.SSLPORT) || Number(settings?.sslport) || 3443
+      : Number(process.env.PORT) || Number(settings?.port) || 3000
+
+    return { scheme: ssl ? 'wss' : 'ws', port }
+  }
+
+  /**
    * Build a ContainerConfig for the mayara-server container with the
    * given tag. Used at startup, when applying updates, and after a
    * background token mint completes — signalk-container drift-detects
@@ -525,9 +562,14 @@ module.exports = function (app: MayaraServerAPI): Plugin {
    * transparently.
    *
    * Default nav-address is the upstream Signal K server itself:
-   *   - `ws:127.0.0.1:${SK_PORT}` plus `MAYARA_SIGNALK_TOKEN` env var
-   *     when a cached device token exists (full WS path → AIS REST
-   *     seeding works inside the container).
+   *   - `${ws|wss}:127.0.0.1:${SK_PORT}` plus `MAYARA_SIGNALK_TOKEN`
+   *     env var when a cached device token exists (full WS path → AIS
+   *     REST seeding works inside the container). The scheme and port
+   *     are derived from the live SK config (`resolveSignalkLoopback`),
+   *     not hardcoded — a TLS-enabled SK only speaks `wss:` and serves
+   *     plain HTTP as a 302→HTTPS redirect that mayara's discovery
+   *     client can't follow. `--accept-invalid-certs` is added for the
+   *     `wss:` loopback (self-signed localhost cert).
    *   - `tcp:127.0.0.1:${TCPSTREAMPORT}` otherwise (legacy delta
    *     stream; AIS overlay still works but only fills from live
    *     deltas, not the initial REST snapshot).
@@ -550,7 +592,7 @@ module.exports = function (app: MayaraServerAPI): Plugin {
     const userArgs = currentSettings?.mayaraArgs ?? []
     const userOverridesNav = userArgs.some((a) => a === '-n' || a === '--navigation-address')
 
-    const skPort = Number(process.env.PORT) || 3000
+    const sk = resolveSignalkLoopback()
     const tcpPort = Number(process.env.TCPSTREAMPORT) || 8375
     const dataDir = app.getDataDirPath()
     const cachedToken = userOverridesNav ? undefined : readCachedToken(dataDir)
@@ -560,7 +602,24 @@ module.exports = function (app: MayaraServerAPI): Plugin {
 
     if (!userOverridesNav) {
       if (cachedToken !== undefined) {
-        injected.push('-n', `ws:127.0.0.1:${skPort}`)
+        // Derive the scheme + port from the live Signal K server config
+        // rather than hardcoding `ws:` and `process.env.PORT`. On a
+        // TLS-enabled SK the plain-HTTP listener only 302-redirects to
+        // HTTPS, and mayara's discovery client rejects the redirect (it
+        // requires a 200 and does not follow `Location`) — so `ws:` to
+        // the HTTP port loops forever and no AIS/nav ever reaches the
+        // radar. `wss:` against the SSL port is the only path that
+        // completes discovery (the SK discovery doc advertises only
+        // `wss://` when ssl is on).
+        injected.push('-n', `${sk.scheme}:127.0.0.1:${sk.port}`)
+        // mayara refuses to start HTTPS discovery against a self-signed
+        // cert without this, and re-checks it on the WSS upgrade. The SK
+        // loopback cert is self-signed; accepting it is safe because the
+        // connection never leaves 127.0.0.1 (no MITM surface). Only
+        // injected for the secure scheme.
+        if (sk.scheme === 'wss') {
+          injected.push('--accept-invalid-certs')
+        }
         env.MAYARA_SIGNALK_TOKEN = cachedToken
       } else {
         injected.push('-n', `tcp:127.0.0.1:${tcpPort}`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -528,18 +528,21 @@ module.exports = function (app: MayaraServerAPI): Plugin {
    * advertised one (`getExternalPort()` may honor `EXTERNALPORT` or a
    * reverse-proxy port that isn't reachable on loopback).
    *
-   * Source of truth, in priority order:
-   *   1. The live SK runtime config (`app.config.settings`). This is the
-   *      only reliable signal — `process.env.PORT` alone is the plain-
-   *      HTTP port even on a TLS server (where the API lives on the SSL
-   *      port). The `@signalk/server-api` types don't declare `config`,
-   *      so it's an untyped, fully optional-chained read.
-   *   2. Environment fallback when config is unreadable: `SSLPORT`
-   *      implies TLS; otherwise plain HTTP on `PORT`.
-   *   3. Final fallback: plain `ws` on 3000 (the historical default).
+   * TLS detection: prefer `settings.ssl` when it's an explicit boolean;
+   * otherwise infer TLS from the presence of the `SSLPORT` env var. We
+   * read `app.config.settings` because `process.env.PORT` alone is the
+   * plain-HTTP port even on a TLS server (where the API lives on the SSL
+   * port). The `@signalk/server-api` types don't declare `config`, so
+   * it's an untyped, fully optional-chained read.
    *
-   * The port resolution mirrors signalk-server's own `getSslPort` /
-   * `getHttpPort` (`SSLPORT||sslport||3443` and `PORT||port||3000`).
+   * Port resolution mirrors signalk-server's own `getSslPort` /
+   * `getHttpPort`, where the env var takes precedence over the config
+   * value:
+   *   - TLS:   `SSLPORT || settings.sslport || 3443`
+   *   - plain: `PORT    || settings.port    || 3000`
+   *
+   * With neither config nor env present this resolves to the historical
+   * default of plain `ws` on 3000.
    */
   function resolveSignalkLoopback(): { scheme: 'ws' | 'wss'; port: number } {
     const cfg = (app as unknown as { config?: { settings?: Record<string, unknown> } }).config

--- a/test/container-integration.test.ts
+++ b/test/container-integration.test.ts
@@ -727,6 +727,26 @@ describe('mayara-server-signalk-plugin container integration', () => {
       await plugin.stop()
     })
 
+    it('falls back to the default SSL port 3443 when ssl is on but sslport is unset', async () => {
+      // Locks in the getSslPort fallback (SSLPORT || sslport || 3443) so
+      // a regression in the default doesn't go unnoticed.
+      const tokenModule = await loadTokenMock()
+      vi.mocked(tokenModule.readCachedToken).mockReturnValue('cached-jwt-abc')
+
+      const { containers, plugin } = await loadPlugin(
+        { requestSignalkToken: true },
+        { settings: { ssl: true } }
+      )
+      const { config } = containers._calls.ensureRunning[0]
+      const command = config.command ?? []
+      const navIdx = command.indexOf('-n')
+      expect(command[navIdx + 1]).toBe('wss:127.0.0.1:3443')
+      expect(command).toContain('--accept-invalid-certs')
+
+      vi.mocked(tokenModule.readCachedToken).mockReturnValue(undefined)
+      await plugin.stop()
+    })
+
     it('uses the configured non-SSL port from app.config when TLS is off', async () => {
       // Port must track the live SK config, not a frozen process.env.PORT
       // — the user switches the SK port on dev machines.

--- a/test/container-integration.test.ts
+++ b/test/container-integration.test.ts
@@ -181,9 +181,14 @@ interface MockApp {
   savePluginOptions: ReturnType<typeof vi.fn>
   radarApi: { register: ReturnType<typeof vi.fn>; unRegister: ReturnType<typeof vi.fn> }
   binaryStreamManager: undefined
+  // Mirrors signalk-server's runtime `app.config`. The public
+  // `@signalk/server-api` types don't declare it, so the plugin reads it
+  // via an untyped cast; tests populate `settings.ssl`/`sslport`/`port`
+  // to drive the nav-address scheme/port resolution.
+  config?: { settings?: { ssl?: boolean; sslport?: number; port?: number } }
 }
 
-function makeMockApp(): MockApp {
+function makeMockApp(config?: MockApp['config']): MockApp {
   return {
     debug: vi.fn(),
     error: vi.fn(),
@@ -192,6 +197,7 @@ function makeMockApp(): MockApp {
     // Opaque string — mayara no longer reads or writes anything in
     // getDataDirPath() now that the hash-file workaround is gone.
     getDataDirPath: () => '/tmp/mayara-test',
+    config,
     // SignalK persistence API: writes to plugin-config-data/<pluginId>.json
     // The signature is (config, callback) where callback gets a NodeJS.ErrnoException | null.
     savePluginOptions: vi.fn(
@@ -298,11 +304,14 @@ interface LoadedPlugin {
   router: CapturedRouter
 }
 
-async function loadPlugin(initialConfig: Record<string, unknown> = {}): Promise<LoadedPlugin> {
+async function loadPlugin(
+  initialConfig: Record<string, unknown> = {},
+  appConfig?: MockApp['config']
+): Promise<LoadedPlugin> {
   const containers = makeMockContainerManager()
   globalThis.__signalk_containerManager = containers
 
-  const app = makeMockApp()
+  const app = makeMockApp(appConfig)
 
   // Force a fresh module load each test so module-level state doesn't leak.
   vi.resetModules()
@@ -678,15 +687,61 @@ describe('mayara-server-signalk-plugin container integration', () => {
       const tokenModule = await loadTokenMock()
       vi.mocked(tokenModule.readCachedToken).mockReturnValue('cached-jwt-abc')
 
+      // No app.config / no SSLPORT env → non-TLS default: plain ws:.
       const { containers, plugin } = await loadPlugin({ requestSignalkToken: true })
       const { config } = containers._calls.ensureRunning[0]
       const command = config.command ?? []
       expect(command).not.toContain('--signalk-token-file')
+      // Plain ws → no cert-acceptance flag.
+      expect(command).not.toContain('--accept-invalid-certs')
       const navIdx = command.indexOf('-n')
       expect(command[navIdx + 1]).toMatch(/^ws:127\.0\.0\.1:\d+$/)
       expect(config.env).toEqual({ MAYARA_SIGNALK_TOKEN: 'cached-jwt-abc' })
       // No bind mount needed for the token under env-var delivery.
       expect(config.volumes).toBeUndefined()
+
+      vi.mocked(tokenModule.readCachedToken).mockReturnValue(undefined)
+      await plugin.stop()
+    })
+
+    it('uses wss: + --accept-invalid-certs and the SSL port when SK has TLS enabled', async () => {
+      // A TLS-enabled SK only serves wss:// (plain HTTP 302-redirects to
+      // HTTPS, which mayara's discovery client can't follow). The
+      // nav-address must therefore be wss: on the SSL port, with
+      // --accept-invalid-certs for the self-signed loopback cert.
+      const tokenModule = await loadTokenMock()
+      vi.mocked(tokenModule.readCachedToken).mockReturnValue('cached-jwt-abc')
+
+      const { containers, plugin } = await loadPlugin(
+        { requestSignalkToken: true },
+        { settings: { ssl: true, sslport: 8443 } }
+      )
+      const { config } = containers._calls.ensureRunning[0]
+      const command = config.command ?? []
+      const navIdx = command.indexOf('-n')
+      expect(command[navIdx + 1]).toBe('wss:127.0.0.1:8443')
+      expect(command).toContain('--accept-invalid-certs')
+      expect(config.env).toEqual({ MAYARA_SIGNALK_TOKEN: 'cached-jwt-abc' })
+
+      vi.mocked(tokenModule.readCachedToken).mockReturnValue(undefined)
+      await plugin.stop()
+    })
+
+    it('uses the configured non-SSL port from app.config when TLS is off', async () => {
+      // Port must track the live SK config, not a frozen process.env.PORT
+      // — the user switches the SK port on dev machines.
+      const tokenModule = await loadTokenMock()
+      vi.mocked(tokenModule.readCachedToken).mockReturnValue('cached-jwt-abc')
+
+      const { containers, plugin } = await loadPlugin(
+        { requestSignalkToken: true },
+        { settings: { ssl: false, port: 3001 } }
+      )
+      const { config } = containers._calls.ensureRunning[0]
+      const command = config.command ?? []
+      const navIdx = command.indexOf('-n')
+      expect(command[navIdx + 1]).toBe('ws:127.0.0.1:3001')
+      expect(command).not.toContain('--accept-invalid-certs')
 
       vi.mocked(tokenModule.readCachedToken).mockReturnValue(undefined)
       await plugin.stop()


### PR DESCRIPTION
## Summary

- The plugin hardcoded mayara's upstream nav-address as `-n ws:127.0.0.1:${process.env.PORT||3000}` for the token (WS) transport. On a TLS-enabled Signal K server the plain-HTTP listener only 302-redirects to HTTPS, and mayara-server's discovery client requires a 200 and does not follow `Location` — so it loops on `GET http://127.0.0.1:PORT/signalk` forever and no AIS/nav data ever reaches the radar overlay. The hardcoded port also breaks any non-3000 deployment (e.g. switching the SK port on a dev box).
- New `resolveSignalkLoopback()` derives the scheme (`ws`/`wss`) and port from the live `app.config.settings` (`ssl ? sslport : port`), mirroring signalk-server's own `getHttpPort`/`getSslPort`, with an env fallback (`SSLPORT`/`PORT`) and the historical `ws:3000` as the final fallback. Uses the *local* listener port rather than `getExternalPort()` because the container runs host-networked and reaches SK over `127.0.0.1`.
- For the `wss:` loopback it injects `--accept-invalid-certs` — mayara won't start HTTPS discovery against the self-signed localhost cert without it, and accepting it is safe on `127.0.0.1` (no MITM surface). Only injected for the secure scheme.
- User-supplied `-n` in `mayaraArgs` still wins and suppresses both the injected nav-address and the cert flag.

The token-acquisition HTTP path in `signalk-token.ts` shares the same http-vs-https assumption; that is a separate logical change and will be a follow-up PR.

## Tested

- `npm run build:all` (lint + tsc + webpack + vitest): 78/78 tests pass.
- Added tests asserting `wss:` + `--accept-invalid-certs` on the SSL port when `settings.ssl` is true, the configured non-SSL port when off, and the `3443` default-SSL-port fallback when `sslport` is omitted; existing non-TLS `ws:` default behavior unchanged.
- Reproduced the failure on a TLS-secured local SK: container ran `-n ws:127.0.0.1:80` and looped on `Signal K discovery: GET http://127.0.0.1:80/signalk` every 5s; confirmed the SK discovery doc advertises only `wss://` and that plain HTTP returns a 302 to HTTPS.
- `cr review` clean (1 trivial nitpick, addressed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Replaces hardcoded mayara upstream nav-address configuration with runtime resolution from the Signal K server's live configuration to support TLS-enabled deployments. This fixes a critical issue where TLS-secured Signal K servers return HTTP 302 redirects that mayara's discovery client cannot follow, resulting in missing AIS/navigation data.

## Changes

**src/index.ts**

Introduces `resolveSignalkLoopback()` helper that derives the correct WebSocket scheme (`ws` or `wss`) and port through the following priority:
1. Live Signal K runtime config (`app.config.settings.ssl`, `app.config.settings.sslport`, `app.config.settings.port`)
2. Environment variables (`SSLPORT`, `PORT`)
3. Default ports (`3443` for SSL, `3000` for plain HTTP)

Updates the container configuration logic to:
- Apply the derived scheme and port to the mayara navigation address (`-n`) parameter when a cached Signal K device token exists
- Automatically inject `--accept-invalid-certs` flag when the derived scheme is `wss` to permit loopback self-signed TLS certificates
- Allow user-supplied `-n` values in mayaraArgs to take precedence, suppressing the injected nav-address and cert flag

**test/container-integration.test.ts**

Extends the mocked Signal K app to support `config.settings` with `ssl`, `sslport`, and `port` properties. Updates the plugin loader helper to accept `appConfig` for test-driven nav-address resolution. Adds comprehensive test coverage for:
- Plain HTTP scenarios using `ws:` scheme without certificate flags
- TLS scenarios using `wss:` scheme with `--accept-invalid-certs`
- Fallback SSL port (`3443`) when `sslport` is unset
- Configuration-driven port selection based on TLS status

## Testing

All 78 tests pass. Tests validate correct scheme/port derivation for both TLS and non-TLS configurations, certificate flag injection for secure schemes, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->