### PR TITLE
fix(token): acquire Signal K device token over https on TLS servers

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -496,6 +496,19 @@ module.exports = function (app) {
         return { scheme: ssl ? 'wss' : 'ws', port };
     }
     /**
+     * Same ssl/port source of truth as `resolveSignalkLoopback`, mapped to
+     * the HTTP(S) scheme the device-token flow needs. The two must stay in
+     * lock-step: when SK is TLS-enabled it serves the access-request API
+     * only over https (the plain-HTTP listener 302-redirects, dropping the
+     * POST body), exactly as it serves the data stream only over wss.
+     * Deriving both from the one resolver guarantees the nav transport and
+     * the token flow never disagree about whether SK is secured.
+     */
+    function resolveSignalkApi() {
+        const { scheme, port } = resolveSignalkLoopback();
+        return { scheme: scheme === 'wss' ? 'https' : 'http', port };
+    }
+    /**
      * Build a ContainerConfig for the mayara-server container with the
      * given tag. Used at startup, when applying updates, and after a
      * background token mint completes — signalk-container drift-detects
@@ -621,7 +634,11 @@ module.exports = function (app) {
             app.debug('Signal K token cached; container started with WS transport');
             return;
         }
-        const skPort = Number(process.env.PORT) || 3000;
+        // Derive scheme + port from the live SK config (same source of
+        // truth as the nav transport) so a TLS-enabled server is reached
+        // over https — its plain-HTTP listener 302-redirects and drops the
+        // POST body, so http would never mint a token.
+        const sk = resolveSignalkApi();
         // Request `readwrite` so mayara can later push deltas back into SK
         // (radar targets, MARPA tracks, heading echoes, guard-zone
         // notifications). Today the token only reads the AIS REST snapshot,
@@ -631,7 +648,8 @@ module.exports = function (app) {
         // writeback features land in mayara-server.
         const begin = await (0, signalk_token_1.beginTokenRequest)({
             dataDir,
-            signalkPort: skPort,
+            signalkPort: sk.port,
+            ssl: sk.scheme === 'https',
             clientId: PLUGIN_ID,
             description: 'MaYaRa Radar (Server) — AIS overlay seeding + radar/target/notification writebacks',
             permissions: 'readwrite'
@@ -664,9 +682,10 @@ module.exports = function (app) {
         app.setPluginStatus('Awaiting Signal K token approval — see Security → Access Requests');
         app.debug(`Awaiting approval at ${begin.href} (request ${begin.requestId}). ` +
             `Set plugin config "requestSignalkToken" to false to suppress this.`);
-        const token = await (0, signalk_token_1.awaitApproval)(begin.href, skPort, () => tokenPollerCancelled, (msg) => {
+        const token = await (0, signalk_token_1.awaitApproval)(begin.href, sk.port, () => tokenPollerCancelled, (msg) => {
             app.debug(msg);
-        });
+        }, undefined, // keep the default poll interval
+        sk.scheme === 'https');
         if (!token) {
             // Denied, expired, or plugin stopped. Either way, leave the
             // container on its existing transport; user can request again

--- a/src/index.ts
+++ b/src/index.ts
@@ -558,6 +558,20 @@ module.exports = function (app: MayaraServerAPI): Plugin {
   }
 
   /**
+   * Same ssl/port source of truth as `resolveSignalkLoopback`, mapped to
+   * the HTTP(S) scheme the device-token flow needs. The two must stay in
+   * lock-step: when SK is TLS-enabled it serves the access-request API
+   * only over https (the plain-HTTP listener 302-redirects, dropping the
+   * POST body), exactly as it serves the data stream only over wss.
+   * Deriving both from the one resolver guarantees the nav transport and
+   * the token flow never disagree about whether SK is secured.
+   */
+  function resolveSignalkApi(): { scheme: 'http' | 'https'; port: number } {
+    const { scheme, port } = resolveSignalkLoopback()
+    return { scheme: scheme === 'wss' ? 'https' : 'http', port }
+  }
+
+  /**
    * Build a ContainerConfig for the mayara-server container with the
    * given tag. Used at startup, when applying updates, and after a
    * background token mint completes — signalk-container drift-detects
@@ -689,7 +703,11 @@ module.exports = function (app: MayaraServerAPI): Plugin {
       return
     }
 
-    const skPort = Number(process.env.PORT) || 3000
+    // Derive scheme + port from the live SK config (same source of
+    // truth as the nav transport) so a TLS-enabled server is reached
+    // over https — its plain-HTTP listener 302-redirects and drops the
+    // POST body, so http would never mint a token.
+    const sk = resolveSignalkApi()
     // Request `readwrite` so mayara can later push deltas back into SK
     // (radar targets, MARPA tracks, heading echoes, guard-zone
     // notifications). Today the token only reads the AIS REST snapshot,
@@ -699,7 +717,8 @@ module.exports = function (app: MayaraServerAPI): Plugin {
     // writeback features land in mayara-server.
     const begin = await beginTokenRequest({
       dataDir,
-      signalkPort: skPort,
+      signalkPort: sk.port,
+      ssl: sk.scheme === 'https',
       clientId: PLUGIN_ID,
       description:
         'MaYaRa Radar (Server) — AIS overlay seeding + radar/target/notification writebacks',
@@ -742,11 +761,13 @@ module.exports = function (app: MayaraServerAPI): Plugin {
 
     const token = await awaitApproval(
       begin.href,
-      skPort,
+      sk.port,
       () => tokenPollerCancelled,
       (msg) => {
         app.debug(msg)
-      }
+      },
+      undefined, // keep the default poll interval
+      sk.scheme === 'https'
     )
     if (!token) {
       // Denied, expired, or plugin stopped. Either way, leave the

--- a/src/signalk-token.ts
+++ b/src/signalk-token.ts
@@ -1,8 +1,80 @@
 import { existsSync, readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
+import { request as httpsRequest } from 'https'
 
 const TOKEN_FILENAME = 'signalk-token'
 const POLL_INTERVAL_MS = 5_000
+
+/** Minimal response shape both transports below resolve to. */
+interface JsonResponse {
+  status: number
+  ok: boolean
+  json: () => Promise<unknown>
+}
+
+/**
+ * Issue a JSON request to the local Signal K server and resolve the
+ * parsed body lazily (matching the `fetch` Response surface this module
+ * already uses: `.status`, `.ok`, `.json()`).
+ *
+ * Plain HTTP goes through global `fetch` unchanged. HTTPS goes through
+ * `node:https` with `rejectUnauthorized: false`, because Signal K's
+ * loopback TLS cert is self-signed *and* its SAN never contains
+ * `127.0.0.1` (SK generates a `CN=localhost`/no-SAN cert; other SK cert
+ * tooling covers only the LAN hostname/IP) — so neither plain `fetch`
+ * nor CA-trust can validate a `https://127.0.0.1` connection. Skipping
+ * verification is safe here: the request never leaves the loopback
+ * interface, so there is no MITM surface, and it mirrors what Signal K's
+ * own outbound client does for self-signed peers (`rejectUnauthorized:
+ * !selfsignedcert`). `node:https` is a built-in, so this needs no extra
+ * dependency and no per-request `undici` dispatcher.
+ *
+ * The transport is chosen by the URL scheme, not a flag: only `https:`
+ * URLs (which this module builds solely for the loopback `127.0.0.1`
+ * host) get the verification-disabled `node:https` path, so an absolute
+ * `http://` href can never accidentally route through it.
+ */
+async function requestJson(
+  method: 'GET' | 'POST',
+  url: string,
+  body: string | undefined
+): Promise<JsonResponse> {
+  if (!url.startsWith('https:')) {
+    const res = await fetch(url, {
+      method,
+      headers: body !== undefined ? { 'Content-Type': 'application/json' } : undefined,
+      body
+    })
+    return { status: res.status, ok: res.ok, json: () => res.json() }
+  }
+
+  return new Promise<JsonResponse>((resolve, reject) => {
+    const req = httpsRequest(
+      url,
+      {
+        method,
+        rejectUnauthorized: false,
+        headers: body !== undefined ? { 'Content-Type': 'application/json' } : undefined
+      },
+      (res) => {
+        const chunks: Buffer[] = []
+        res.on('data', (c: Buffer) => chunks.push(c))
+        res.on('end', () => {
+          const status = res.statusCode ?? 0
+          const text = Buffer.concat(chunks).toString('utf8')
+          resolve({
+            status,
+            ok: status >= 200 && status < 300,
+            json: () => Promise.resolve(text ? (JSON.parse(text) as unknown) : undefined)
+          })
+        })
+      }
+    )
+    req.on('error', reject)
+    if (body !== undefined) req.write(body)
+    req.end()
+  })
+}
 
 export type EnsureResult =
   | { kind: 'cached'; token: string }
@@ -14,6 +86,13 @@ export type EnsureResult =
 export interface EnsureOptions {
   dataDir: string
   signalkPort: number
+  /**
+   * True when the local Signal K server is TLS-enabled. Switches the
+   * access-request POST to `https://127.0.0.1` with verification
+   * disabled (see `requestJson`). Defaults to false (plain HTTP) to
+   * preserve the historical path.
+   */
+  ssl?: boolean
   clientId: string
   description: string
   permissions?: 'readonly' | 'readwrite' | 'admin'
@@ -90,18 +169,19 @@ export async function beginTokenRequest(opts: EnsureOptions): Promise<EnsureResu
   const cached = readCachedToken(opts.dataDir)
   if (cached) return { kind: 'cached', token: cached }
 
-  const url = `http://127.0.0.1:${opts.signalkPort}/signalk/v1/access/requests`
-  let res: Response
+  const scheme = opts.ssl ? 'https' : 'http'
+  const url = `${scheme}://127.0.0.1:${opts.signalkPort}/signalk/v1/access/requests`
+  let res: JsonResponse
   try {
-    res = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
+    res = await requestJson(
+      'POST',
+      url,
+      JSON.stringify({
         clientId: opts.clientId,
         description: opts.description,
         permissions: opts.permissions ?? 'readonly'
       })
-    })
+    )
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
     return { kind: 'error', message: `POST ${url} failed: ${msg}` }
@@ -150,30 +230,35 @@ export async function beginTokenRequest(opts: EnsureOptions): Promise<EnsureResu
  *
  * The href returned by SK is a relative path like
  * `/signalk/v1/requests/<uuid>`; we resolve it against
- * `http://127.0.0.1:${signalkPort}`.
+ * `${scheme}://127.0.0.1:${signalkPort}` (https when `ssl`).
  *
  * `pollIntervalMs` defaults to 5s in production (an admin clicking
  * approve is a slow human action; we don't need to poll faster than
  * that). Tests override it to single-digit milliseconds.
+ *
+ * `ssl` is a trailing optional so the existing positional callers keep
+ * working; defaults to plain HTTP.
  */
 export async function awaitApproval(
   href: string,
   signalkPort: number,
   isCancelled: () => boolean,
   log: (msg: string) => void,
-  pollIntervalMs: number = POLL_INTERVAL_MS
+  pollIntervalMs: number = POLL_INTERVAL_MS,
+  ssl: boolean = false
 ): Promise<string | undefined> {
+  const scheme = ssl ? 'https' : 'http'
   const url = href.startsWith('http')
     ? href
-    : `http://127.0.0.1:${signalkPort}${href.startsWith('/') ? '' : '/'}${href}`
+    : `${scheme}://127.0.0.1:${signalkPort}${href.startsWith('/') ? '' : '/'}${href}`
 
   while (!isCancelled()) {
     await sleep(pollIntervalMs)
     if (isCancelled()) return undefined
 
-    let res: Response
+    let res: JsonResponse
     try {
-      res = await fetch(url, { method: 'GET' })
+      res = await requestJson('GET', url, undefined)
     } catch (err) {
       log(
         `Token poll fetch failed (will retry): ${err instanceof Error ? err.message : String(err)}`

--- a/test/signalk-token.test.ts
+++ b/test/signalk-token.test.ts
@@ -2,6 +2,16 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
+import { EventEmitter } from 'events'
+import type { RequestOptions } from 'https'
+
+// The module imports `request` from 'https' for its TLS path. ESM
+// namespace exports aren't spy-able, so mock the module and drive the
+// exported mock per test via `httpsRequestMock`. `vi.hoisted` makes the
+// mock fn available inside the hoisted `vi.mock` factory.
+const { httpsRequestMock } = vi.hoisted(() => ({ httpsRequestMock: vi.fn() }))
+vi.mock('https', () => ({ request: httpsRequestMock }))
+
 import {
   awaitApproval,
   beginTokenRequest,
@@ -12,9 +22,41 @@ import {
 let dataDir: string
 let originalFetch: typeof globalThis.fetch
 
+/**
+ * Program the mocked `https.request` to capture the URL + options and
+ * replay `status`/`body`. Returns the captured args for assertions. The
+ * module calls it as `request(url, options, callback)`.
+ */
+function stubHttpsRequest(status: number, body: unknown) {
+  const captured: { url?: string; options?: RequestOptions } = {}
+  httpsRequestMock.mockImplementation(
+    (url: string, options: RequestOptions, cb: (res: EventEmitter) => void) => {
+      captured.url = url
+      captured.options = options
+      const res = new EventEmitter() as EventEmitter & { statusCode: number }
+      res.statusCode = status
+      // Defer so the caller can attach .on('data'/'end') first.
+      queueMicrotask(() => {
+        res.emit('data', Buffer.from(JSON.stringify(body)))
+        res.emit('end')
+      })
+      const req = new EventEmitter() as EventEmitter & {
+        write: () => void
+        end: () => void
+      }
+      req.write = () => {}
+      req.end = () => {}
+      cb(res)
+      return req
+    }
+  )
+  return captured
+}
+
 beforeEach(() => {
   dataDir = mkdtempSync(join(tmpdir(), 'mayara-token-test-'))
   originalFetch = globalThis.fetch
+  httpsRequestMock.mockReset()
 })
 
 afterEach(() => {
@@ -182,6 +224,51 @@ describe('signalk-token: beginTokenRequest', () => {
     expect(body.clientId).toBe('mayara-test')
     expect(body.permissions).toBe('readonly')
   })
+
+  it('posts over https with verification disabled when ssl is true', async () => {
+    // A TLS-enabled SK serves the access-request API only over https
+    // (plain HTTP 302-redirects and drops the POST body). The cert is
+    // self-signed with no 127.0.0.1 SAN, so verification must be off.
+    const captured = stubHttpsRequest(202, {
+      state: 'PENDING',
+      requestId: 'req-tls',
+      statusCode: 202,
+      href: '/signalk/v1/requests/req-tls'
+    })
+    // Fail loudly if it wrongly takes the plain-fetch path.
+    globalThis.fetch = vi.fn(() => Promise.reject(new Error('fetch should not be used for ssl')))
+
+    const result = await beginTokenRequest({
+      dataDir,
+      signalkPort: 3443,
+      ssl: true,
+      clientId: 'mayara-test',
+      description: 'Mayara Radar test',
+      permissions: 'readwrite'
+    })
+
+    expect(result).toEqual({
+      kind: 'pending',
+      requestId: 'req-tls',
+      href: '/signalk/v1/requests/req-tls'
+    })
+    expect(captured.url).toBe('https://127.0.0.1:3443/signalk/v1/access/requests')
+    expect(captured.options?.rejectUnauthorized).toBe(false)
+  })
+
+  it('stays on http (global fetch) when ssl is omitted', async () => {
+    // Regression guard: the default path must not touch https.request.
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve(makeFetchResponse(202, { state: 'PENDING', requestId: 'r', href: '/x' }))
+    )
+    await beginTokenRequest({
+      dataDir,
+      signalkPort: 3000,
+      clientId: 'mayara-test',
+      description: 'x'
+    })
+    expect(httpsRequestMock).not.toHaveBeenCalled()
+  })
 })
 
 describe('signalk-token: awaitApproval', () => {
@@ -269,5 +356,26 @@ describe('signalk-token: awaitApproval', () => {
       5
     )
     expect(urls[0]).toBe('http://127.0.0.1:4321/signalk/v1/requests/r')
+  })
+
+  it('resolves a relative href against https with verification off when ssl is true', async () => {
+    const captured = stubHttpsRequest(200, {
+      state: 'COMPLETED',
+      requestId: 'r',
+      accessRequest: { token: 'tls-token' }
+    })
+    globalThis.fetch = vi.fn(() => Promise.reject(new Error('fetch should not be used for ssl')))
+
+    const token = await awaitApproval(
+      '/signalk/v1/requests/r',
+      3443,
+      () => false,
+      () => {},
+      5,
+      true
+    )
+    expect(token).toBe('tls-token')
+    expect(captured.url).toBe('https://127.0.0.1:3443/signalk/v1/requests/r')
+    expect(captured.options?.rejectUnauthorized).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

- The device-token flow POSTed the access request to `http://127.0.0.1:${PORT}` and polled the same URL. On a TLS-enabled Signal K server the plain-HTTP listener only 302-redirects to HTTPS and the POST body is dropped across the redirect, so a fresh token could never be minted — the container stayed on the unauthenticated TCP fallback and the AIS REST snapshot never seeded. (Cached tokens were unaffected, which kept this latent; it's the sibling of the nav-address bug fixed in #55.)
- Derive scheme + port from the same source of truth as the nav transport via a new `resolveSignalkApi()` that maps `resolveSignalkLoopback()` to http/https, so the two paths never disagree about whether SK is secured.
- The https path uses the built-in `node:https` with `rejectUnauthorized: false`, not `fetch` + an undici dispatcher. SK's loopback cert is self-signed and its SAN never contains `127.0.0.1` (SK generates a `CN=localhost`/no-SAN cert; other SK cert tooling covers only the LAN host/IP), so CA-trust cannot validate a `https://127.0.0.1` connection. Skipping verification is safe on loopback (no MITM surface) and mirrors what SK's own outbound client does for self-signed peers. Using `node:https` keeps this dependency-free. Transport is selected by the URL scheme, so an absolute `http://` href can never route through the insecure path.

## Tested

- `npm run build:all` (lint + tsc + webpack + vitest): 81/81 tests pass, including new tests asserting the https URL and `rejectUnauthorized: false` on the ssl path, and that the default path never touches `https.request`.
- End-to-end against a live TLS-secured Signal K (2.28.0-beta.2) on `:443`: the compiled module POSTed over `https://127.0.0.1:443` and received `202 PENDING` with a real `requestId`/`href` — confirming the self-signed loopback cert is accepted and a request is created.
- `cr review` clean (no findings).

`resolveSignalkApi()` is a private inner function covered transitively by the container-integration token-flow tests; no exported-helper unit test added.