### PR TITLE
chore(release): 1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "signalk-plugin-enabled-by-default": true,


### PR DESCRIPTION
## Summary

Patch release. Ships the two TLS-related fixes merged since 1.2.1:

- **fix(container): derive nav-address scheme/port from live SK config** (#55) — mayara now reaches a TLS-enabled Signal K over `wss:` on the SSL port instead of a hardcoded `ws:` on `process.env.PORT`, so AIS/nav data flows on secured servers and on non-3000 ports.
- **fix(token): acquire Signal K device token over https on TLS servers** (#56) — the device-token request now uses https on a TLS server, so a fresh token can be minted (the plain-HTTP POST was lost across SK's HTTP→HTTPS redirect).

## Tested

- `npm run build:all`: 81/81 tests pass.