### PR TITLE
feat(status): surface "update available" in the plugin status line

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -912,6 +912,13 @@ module.exports = function (app) {
                 reconnectInterval = null;
             }
             updateRadars(radarIds, settings);
+            // A boot that reaches "Connected" via reconnect (mayara not ready
+            // at startup) skips connectAndDiscover, so recompute the update
+            // hint here too — same best-effort, non-blocking refresh.
+            void refreshUpdateHint().then(() => {
+                if (isConnected)
+                    app.setPluginStatus(connectedStatus(knownRadars.size));
+            });
             if (discoveryInterval) {
                 clearInterval(discoveryInterval);
             }

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -54,6 +54,10 @@ module.exports = function (app) {
     let tokenPollerCancelled = false;
     let reconnectInterval = null;
     let isConnected = false;
+    // Appended to the "Connected" status line when a newer container image
+    // is available, so a stale image is visible where the operator already
+    // looks instead of silently running an old build. Empty otherwise.
+    let updateHint = '';
     const knownRadars = new Set();
     // Track the WebSocket upgrade listener so stop() can detach it.
     // The HTTP server outlives plugin restarts (disable/enable, config
@@ -138,6 +142,7 @@ module.exports = function (app) {
                 upgradeListenerServer = null;
             }
             isConnected = false;
+            updateHint = '';
             app.setPluginStatus('Stopped');
         },
         registerWithRouter(router) {
@@ -419,6 +424,8 @@ module.exports = function (app) {
                             });
                         });
                     }
+                    // The freshly-applied image is now current; clear any stale hint.
+                    updateHint = '';
                     app.setPluginStatus(`Updated to mayara-server:${tag}`);
                     res.json({ success: true, tag });
                 }
@@ -839,6 +846,30 @@ module.exports = function (app) {
         }
         await connectAndDiscover(settings);
     }
+    // Compose the "Connected" status line, appending the update hint when
+    // a newer container image is available.
+    function connectedStatus(radarCount) {
+        return `Connected - ${radarCount} radar(s)${updateHint}`;
+    }
+    // Ask signalk-container's (offline-tolerant, cached) update service
+    // whether a newer image exists and set `updateHint` accordingly. Cheap
+    // and best-effort: any failure leaves the hint cleared. Managed mode
+    // only — in external mode the plugin doesn't own the image.
+    async function refreshUpdateHint() {
+        if (currentSettings?.managedContainer === false)
+            return;
+        const containers = getContainerManager();
+        if (!containers)
+            return;
+        try {
+            const result = await containers.updates.checkOne(PLUGIN_ID);
+            updateHint = result.updateAvailable ? ' · update available (click Update)' : '';
+        }
+        catch (err) {
+            app.debug(`Update check failed: ${errMsg(err)}`);
+            updateHint = '';
+        }
+    }
     async function connectAndDiscover(settings) {
         if (!client)
             return;
@@ -846,8 +877,14 @@ module.exports = function (app) {
             const radars = await client.getRadars();
             isConnected = true;
             const radarIds = Object.keys(radars);
-            app.setPluginStatus(`Connected - ${radarIds.length} radar(s) found`);
+            app.setPluginStatus(connectedStatus(radarIds.length));
             updateRadars(radarIds, settings);
+            // Best-effort, non-blocking: surface "update available" in the
+            // status line once the check resolves, so a stale image is visible.
+            void refreshUpdateHint().then(() => {
+                if (isConnected)
+                    app.setPluginStatus(connectedStatus(knownRadars.size));
+            });
             const pollMs = (settings.discoveryPollInterval || 10) * 1000;
             discoveryInterval = setInterval(() => {
                 void pollForRadarChanges(settings);
@@ -869,7 +906,7 @@ module.exports = function (app) {
             const radars = await client.getRadars();
             isConnected = true;
             const radarIds = Object.keys(radars);
-            app.setPluginStatus(`Connected - ${radarIds.length} radar(s) found`);
+            app.setPluginStatus(connectedStatus(radarIds.length));
             if (reconnectInterval) {
                 clearInterval(reconnectInterval);
                 reconnectInterval = null;
@@ -930,7 +967,7 @@ module.exports = function (app) {
             const radars = await client.getRadars();
             const radarIds = Object.keys(radars);
             updateRadars(radarIds, settings);
-            app.setPluginStatus(`Connected - ${radarIds.length} radar(s)`);
+            app.setPluginStatus(connectedStatus(radarIds.length));
         }
         catch (err) {
             isConnected = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1025,6 +1025,13 @@ module.exports = function (app: MayaraServerAPI): Plugin {
 
       updateRadars(radarIds, settings)
 
+      // A boot that reaches "Connected" via reconnect (mayara not ready
+      // at startup) skips connectAndDiscover, so recompute the update
+      // hint here too — same best-effort, non-blocking refresh.
+      void refreshUpdateHint().then(() => {
+        if (isConnected) app.setPluginStatus(connectedStatus(knownRadars.size))
+      })
+
       if (discoveryInterval) {
         clearInterval(discoveryInterval)
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,10 @@ module.exports = function (app: MayaraServerAPI): Plugin {
   let tokenPollerCancelled = false
   let reconnectInterval: ReturnType<typeof setInterval> | null = null
   let isConnected = false
+  // Appended to the "Connected" status line when a newer container image
+  // is available, so a stale image is visible where the operator already
+  // looks instead of silently running an old build. Empty otherwise.
+  let updateHint = ''
   const knownRadars = new Set<string>()
   // Track the WebSocket upgrade listener so stop() can detach it.
   // The HTTP server outlives plugin restarts (disable/enable, config
@@ -169,6 +173,7 @@ module.exports = function (app: MayaraServerAPI): Plugin {
       }
 
       isConnected = false
+      updateHint = ''
       app.setPluginStatus('Stopped')
     },
 
@@ -466,6 +471,8 @@ module.exports = function (app: MayaraServerAPI): Plugin {
             })
           }
 
+          // The freshly-applied image is now current; clear any stale hint.
+          updateHint = ''
           app.setPluginStatus(`Updated to mayara-server:${tag}`)
           res.json({ success: true, tag })
         } catch (err) {
@@ -945,6 +952,29 @@ module.exports = function (app: MayaraServerAPI): Plugin {
     await connectAndDiscover(settings)
   }
 
+  // Compose the "Connected" status line, appending the update hint when
+  // a newer container image is available.
+  function connectedStatus(radarCount: number): string {
+    return `Connected - ${radarCount} radar(s)${updateHint}`
+  }
+
+  // Ask signalk-container's (offline-tolerant, cached) update service
+  // whether a newer image exists and set `updateHint` accordingly. Cheap
+  // and best-effort: any failure leaves the hint cleared. Managed mode
+  // only — in external mode the plugin doesn't own the image.
+  async function refreshUpdateHint(): Promise<void> {
+    if (currentSettings?.managedContainer === false) return
+    const containers = getContainerManager()
+    if (!containers) return
+    try {
+      const result = await containers.updates.checkOne(PLUGIN_ID)
+      updateHint = result.updateAvailable ? ' · update available (click Update)' : ''
+    } catch (err) {
+      app.debug(`Update check failed: ${errMsg(err)}`)
+      updateHint = ''
+    }
+  }
+
   async function connectAndDiscover(settings: Partial<Config>): Promise<void> {
     if (!client) return
 
@@ -953,9 +983,15 @@ module.exports = function (app: MayaraServerAPI): Plugin {
       isConnected = true
 
       const radarIds = Object.keys(radars)
-      app.setPluginStatus(`Connected - ${radarIds.length} radar(s) found`)
+      app.setPluginStatus(connectedStatus(radarIds.length))
 
       updateRadars(radarIds, settings)
+
+      // Best-effort, non-blocking: surface "update available" in the
+      // status line once the check resolves, so a stale image is visible.
+      void refreshUpdateHint().then(() => {
+        if (isConnected) app.setPluginStatus(connectedStatus(knownRadars.size))
+      })
 
       const pollMs = (settings.discoveryPollInterval || 10) * 1000
       discoveryInterval = setInterval(() => {
@@ -980,7 +1016,7 @@ module.exports = function (app: MayaraServerAPI): Plugin {
       isConnected = true
 
       const radarIds = Object.keys(radars)
-      app.setPluginStatus(`Connected - ${radarIds.length} radar(s) found`)
+      app.setPluginStatus(connectedStatus(radarIds.length))
 
       if (reconnectInterval) {
         clearInterval(reconnectInterval)
@@ -1049,7 +1085,7 @@ module.exports = function (app: MayaraServerAPI): Plugin {
       const radarIds = Object.keys(radars)
 
       updateRadars(radarIds, settings)
-      app.setPluginStatus(`Connected - ${radarIds.length} radar(s)`)
+      app.setPluginStatus(connectedStatus(radarIds.length))
     } catch (err) {
       isConnected = false
       app.setPluginError(`Lost connection: ${errMsg(err)}`)

--- a/test/container-integration.test.ts
+++ b/test/container-integration.test.ts
@@ -18,15 +18,20 @@ import type {
 // mock the modules at import time.
 
 vi.mock('../src/mayara-client', () => {
-  return {
-    MayaraClient: vi.fn().mockImplementation(() => ({
+  // A `new`-able stand-in. `vi.fn().mockImplementation(() => ({...}))`
+  // returns an arrow function, which throws "is not a constructor" when
+  // the plugin does `new MayaraClient(...)`, so use a plain function.
+  function MayaraClient() {
+    return {
       getRadars: vi.fn().mockResolvedValue({}),
       getCapabilities: vi.fn().mockResolvedValue({}),
       close: vi.fn(),
       getSpokeStreamUrl: vi.fn().mockReturnValue('ws://localhost:6502/x'),
-      getTargetStreamUrl: vi.fn().mockReturnValue('ws://localhost:6502/y')
-    }))
+      getTargetStreamUrl: vi.fn().mockReturnValue('ws://localhost:6502/y'),
+      getStateStreamUrl: vi.fn().mockReturnValue('ws://localhost:6502/signalk/v1/stream')
+    }
   }
+  return { MayaraClient }
 })
 
 vi.mock('../src/radar-provider', () => ({
@@ -554,6 +559,10 @@ describe('mayara-server-signalk-plugin container integration', () => {
       }
       containers._nextCheckResult = customResult
 
+      // The startup connect path also calls checkOne (to surface the
+      // update hint); clear it so this asserts only the route's call.
+      containers._calls.updateCheckOne = []
+
       const res = makeRes()
       await handler({}, res)
 
@@ -571,6 +580,49 @@ describe('mayara-server-signalk-plugin container integration', () => {
       const res = makeRes()
       await handler({}, res)
       expect(res.statusCode).toBe(503)
+      await plugin.stop()
+    })
+  })
+
+  describe('update-available status hint', () => {
+    it('appends an update hint to the Connected status when one is available', async () => {
+      const containers = makeMockContainerManager()
+      containers._nextCheckResult = {
+        pluginId: 'mayara-server-signalk-plugin',
+        containerName: 'mayara-server',
+        runningTag: 'main',
+        tagKind: 'floating',
+        currentVersion: null,
+        latestVersion: null,
+        updateAvailable: true,
+        reason: 'digest-drift',
+        checkedAt: '2026-06-01T00:00:00.000Z',
+        lastSuccessfulCheckAt: '2026-06-01T00:00:00.000Z',
+        fromCache: false
+      }
+      globalThis.__signalk_containerManager = containers
+      const app = makeMockApp()
+      vi.resetModules()
+      const mod = (await import('../src/index')) as unknown as {
+        default: (a: unknown) => { start: (c: unknown) => void; stop: () => void | Promise<void> }
+      }
+      const plugin = mod.default(app)
+      plugin.start({ managedContainer: true, mayaraVersion: 'main', requestSignalkToken: false })
+      // Allow the connect + async refreshUpdateHint().then() chain to settle.
+      await new Promise<void>((resolve) => setTimeout(resolve, 80))
+
+      const statuses = app.setPluginStatus.mock.calls.map((c) => c[0] as string)
+      expect(statuses.some((s) => s.includes('update available'))).toBe(true)
+      await plugin.stop()
+    })
+
+    it('does not append a hint when no update is available', async () => {
+      // Default mock checkOne returns updateAvailable: false.
+      const { app, plugin } = await loadPlugin({ mayaraVersion: 'main' })
+      await new Promise<void>((resolve) => setTimeout(resolve, 300))
+      const statuses = app.setPluginStatus.mock.calls.map((c) => c[0] as string)
+      expect(statuses.some((s) => s.startsWith('Connected'))).toBe(true)
+      expect(statuses.some((s) => s.includes('update available'))).toBe(false)
       await plugin.stop()
     })
   })


### PR DESCRIPTION
## Summary

- When the managed container ran an outdated floating-tag image, nothing told the operator: plugin status read "Connected - N radar(s)" while a newer image (with fixes) sat unused. A stale container looked healthy and the only symptom was missing functionality — which sends people debugging in the wrong place.
- On connect, run signalk-container's offline-tolerant, cached update check; when a newer image is available, append "· update available (click Update)" to the status line so the stale state is visible where the operator already looks.
- Best-effort and non-blocking: any failure clears the hint and never delays startup. Managed mode only (external mode doesn't own the image). Cleared on a successful Update and on stop().
- Also makes the test-harness `MayaraClient` mock `new`-able — it returned an arrow function, which throws "is not a constructor" and had silently prevented any connect-path test coverage.

## Tested

- `npm run build:all`: 83/83 tests pass, including new tests asserting the hint appears when `checkOne` reports `updateAvailable` and is absent otherwise.
- `cr review` clean (no findings).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
The plugin now surfaces whether a newer mayara-server container image is available directly in the plugin status line, enabling operators to see when a managed container is stale and in need of an update.

## Changes

**src/index.ts:**
- Introduces an `updateHint` state string that tracks whether an update is available
- Adds a `connectedStatus` helper that appends the hint (when present) to the Connected status message
- Implements `refreshUpdateHint`, a best-effort background function that queries signalk-container's update service to check for and set/clear the hint
- On initial connect, after radar discovery (`updateRadars`), triggers `refreshUpdateHint` and refreshes the displayed status once the check resolves (if still connected)
- Reuses the same status formatting during reconnect attempts and after radar discovery polling
- Clears the hint on plugin stop and after successful update/apply operations

**test/container-integration.test.ts:**
- Refactors the MayaraClient mock from an arrow function to a proper constructor function, allowing `new MayaraClient(...)` to work correctly and restoring connect-path test coverage
- Adjusts the `/api/update/check` test to explicitly clear `containers._calls.updateCheckOne` after startup, isolating the route-triggered call from startup behavior
- Adds comprehensive test coverage for the update-available status hint: validates that the hint appears in the Connected status when `checkOne` reports an available update, and is absent otherwise; includes explicit module reloading and async waits to allow status-refresh chains to settle

## Behavior
The update check is best-effort and non-blocking — failures clear the hint and never delay plugin startup. The feature applies only to managed mode; external mode does not own the container image. All 83 tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->