### PR TITLE
chore(release): 1.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "signalk-plugin-enabled-by-default": true,


### PR DESCRIPTION
## Summary

Patch release. Ships the change merged since 1.2.2:

- **feat(status): surface "update available" in the plugin status line** (#58) — when the managed container runs an outdated floating-tag image, the plugin status now shows "· update available (click Update)" instead of silently running a stale build. Also refreshes the hint after a late reconnect.

Released as a patch (maintainer override of the feat→minor default) since it's a small status-line UX addition.

## Tested

- `npm run build:all`: 83/83 tests pass.