### PR TITLE
feat: offer per-PR test images in the version dropdown

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -437,29 +437,50 @@ module.exports = function (app) {
             router.get('/api/gui-url', (_req, res) => {
                 res.json({ url: `${GUI_PROXY_PATH}/` });
             });
-            // Lists available release tags for the version dropdown in the
-            // config panel. signalk-container's update service exposes "what
-            // is the latest" but not "list all" — the latter belongs in the
-            // plugin (it knows which repo to ask). This is the only place
-            // mayara still talks to GitHub directly.
+            // Lists available image tags for the version dropdown in the config
+            // panel: GitHub release tags plus per-PR test images. signalk-container's
+            // update service exposes "what is the latest" but not "list all" — the
+            // latter belongs in the plugin (it knows which repo to ask). This is the
+            // only place mayara still talks to GitHub directly.
             router.get('/api/versions', async (_req, res) => {
-                try {
-                    const ghRes = await fetch('https://api.github.com/repos/MarineYachtRadar/mayara-server/releases?per_page=10', {
-                        headers: { Accept: 'application/vnd.github+json' },
-                        signal: AbortSignal.timeout(10000)
-                    });
-                    if (!ghRes.ok) {
-                        res.status(502).json({ error: 'Failed to fetch releases' });
-                        return;
-                    }
-                    const releases = (await ghRes.json());
-                    res.json(releases
+                const headers = { Accept: 'application/vnd.github+json' };
+                const repo = 'MarineYachtRadar/mayara-server';
+                const releasesP = fetch(`https://api.github.com/repos/${repo}/releases?per_page=10`, {
+                    headers,
+                    signal: AbortSignal.timeout(10000)
+                });
+                // PR test images (tag `pr<N>`) exist only for OPEN PRs carrying the
+                // `build-image` label; the server-side cleanup job deletes the image
+                // when the PR closes. So list open PRs and keep the labeled ones.
+                const pullsP = fetch(`https://api.github.com/repos/${repo}/pulls?state=open&per_page=30`, {
+                    headers,
+                    signal: AbortSignal.timeout(10000)
+                });
+                const [relSettled, pullSettled] = await Promise.allSettled([releasesP, pullsP]);
+                const releases = [];
+                if (relSettled.status === 'fulfilled' && relSettled.value.ok) {
+                    const data = (await relSettled.value.json());
+                    releases.push(...data
                         .filter((r) => !r.draft && SAFE_TAG.test(r.tag_name))
                         .map((r) => ({ tag: r.tag_name, prerelease: r.prerelease })));
                 }
-                catch (err) {
-                    res.status(500).json({ error: errMsg(err) });
+                const prImages = [];
+                if (pullSettled.status === 'fulfilled' && pullSettled.value.ok) {
+                    const pulls = (await pullSettled.value.json());
+                    prImages.push(...pulls
+                        .filter((p) => p.labels.some((l) => l.name === 'build-image'))
+                        .map((p) => ({ tag: `pr${p.number}`, pr: p.number, title: p.title }))
+                        .filter((p) => SAFE_TAG.test(p.tag)));
                 }
+                // Both sources down → 502 so the panel keeps its prior dropdown
+                // (it ignores non-ok responses). One source down → degrade silently.
+                const relFailed = relSettled.status === 'rejected' || !relSettled.value.ok;
+                const pullFailed = pullSettled.status === 'rejected' || !pullSettled.value.ok;
+                if (relFailed && pullFailed) {
+                    res.status(502).json({ error: 'Failed to fetch versions' });
+                    return;
+                }
+                res.json([...releases, ...prImages]);
             });
         }
     };

--- a/src/configpanel/PluginConfigurationPanel.js
+++ b/src/configpanel/PluginConfigurationPanel.js
@@ -368,12 +368,17 @@ export default function PluginConfigurationPanel({ configuration, save }) {
   const containerState = pluginStatus?.container?.state;
   const containerImage = pluginStatus?.container?.image || "";
   const runningTag = containerImage.split(":")[1] || "unknown";
-  const updateAvailable = versions.length > 0 && mayaraVersion === "latest"
-    ? false  // can't compare "latest" to release tags
+  const isPrTag = /^pr\d+$/.test(mayaraVersion);
+  const updateAvailable = isPrTag || mayaraVersion === "latest"
+    ? false  // PR test images and floating "latest" aren't version-compared
     : versions.length > 0 && !versions.some((v) => v.tag === mayaraVersion);
 
-  const stableVersions = versions.filter((v) => !v.prerelease).slice(0, 5);
-  const preVersions = versions.filter((v) => v.prerelease).slice(0, 3);
+  // PR test images carry a `pr` number (no `prerelease`); split them out so
+  // they aren't misclassified as stable releases.
+  const prVersions = versions.filter((v) => typeof v.pr === "number");
+  const releaseVersions = versions.filter((v) => typeof v.pr !== "number");
+  const stableVersions = releaseVersions.filter((v) => !v.prerelease).slice(0, 5);
+  const preVersions = releaseVersions.filter((v) => v.prerelease).slice(0, 3);
 
   return (
     <div style={S.root}>
@@ -454,6 +459,13 @@ export default function PluginConfigurationPanel({ configuration, save }) {
               {stableVersions.map((v, i) => (
                 <option key={v.tag} value={v.tag}>{v.tag}{i === 0 ? " (current stable)" : ""}</option>
               ))}
+              {prVersions.length > 0 && (
+                <optgroup label="PR test images">
+                  {prVersions.map((v) => (
+                    <option key={v.tag} value={v.tag}>{v.tag} — {v.title}</option>
+                  ))}
+                </optgroup>
+              )}
             </select>
             {versionsLoading && <span style={S.hint}>loading...</span>}
             <button

--- a/src/index.ts
+++ b/src/index.ts
@@ -485,37 +485,68 @@ module.exports = function (app: MayaraServerAPI): Plugin {
         res.json({ url: `${GUI_PROXY_PATH}/` })
       })
 
-      // Lists available release tags for the version dropdown in the
-      // config panel. signalk-container's update service exposes "what
-      // is the latest" but not "list all" — the latter belongs in the
-      // plugin (it knows which repo to ask). This is the only place
-      // mayara still talks to GitHub directly.
+      // Lists available image tags for the version dropdown in the config
+      // panel: GitHub release tags plus per-PR test images. signalk-container's
+      // update service exposes "what is the latest" but not "list all" — the
+      // latter belongs in the plugin (it knows which repo to ask). This is the
+      // only place mayara still talks to GitHub directly.
       router.get('/api/versions', async (_req: Request, res: Response) => {
-        try {
-          const ghRes = await fetch(
-            'https://api.github.com/repos/MarineYachtRadar/mayara-server/releases?per_page=10',
-            {
-              headers: { Accept: 'application/vnd.github+json' },
-              signal: AbortSignal.timeout(10000)
-            }
-          )
-          if (!ghRes.ok) {
-            res.status(502).json({ error: 'Failed to fetch releases' })
-            return
-          }
-          const releases = (await ghRes.json()) as {
+        const headers = { Accept: 'application/vnd.github+json' }
+        const repo = 'MarineYachtRadar/mayara-server'
+
+        const releasesP = fetch(`https://api.github.com/repos/${repo}/releases?per_page=10`, {
+          headers,
+          signal: AbortSignal.timeout(10000)
+        })
+        // PR test images (tag `pr<N>`) exist only for OPEN PRs carrying the
+        // `build-image` label; the server-side cleanup job deletes the image
+        // when the PR closes. So list open PRs and keep the labeled ones.
+        const pullsP = fetch(`https://api.github.com/repos/${repo}/pulls?state=open&per_page=30`, {
+          headers,
+          signal: AbortSignal.timeout(10000)
+        })
+
+        const [relSettled, pullSettled] = await Promise.allSettled([releasesP, pullsP])
+
+        const releases: { tag: string; prerelease: boolean }[] = []
+        if (relSettled.status === 'fulfilled' && relSettled.value.ok) {
+          const data = (await relSettled.value.json()) as {
             tag_name: string
             prerelease: boolean
             draft: boolean
           }[]
-          res.json(
-            releases
+          releases.push(
+            ...data
               .filter((r) => !r.draft && SAFE_TAG.test(r.tag_name))
               .map((r) => ({ tag: r.tag_name, prerelease: r.prerelease }))
           )
-        } catch (err) {
-          res.status(500).json({ error: errMsg(err) })
         }
+
+        const prImages: { tag: string; pr: number; title: string }[] = []
+        if (pullSettled.status === 'fulfilled' && pullSettled.value.ok) {
+          const pulls = (await pullSettled.value.json()) as {
+            number: number
+            title: string
+            labels: { name: string }[]
+          }[]
+          prImages.push(
+            ...pulls
+              .filter((p) => p.labels.some((l) => l.name === 'build-image'))
+              .map((p) => ({ tag: `pr${p.number}`, pr: p.number, title: p.title }))
+              .filter((p) => SAFE_TAG.test(p.tag))
+          )
+        }
+
+        // Both sources down → 502 so the panel keeps its prior dropdown
+        // (it ignores non-ok responses). One source down → degrade silently.
+        const relFailed = relSettled.status === 'rejected' || !relSettled.value.ok
+        const pullFailed = pullSettled.status === 'rejected' || !pullSettled.value.ok
+        if (relFailed && pullFailed) {
+          res.status(502).json({ error: 'Failed to fetch versions' })
+          return
+        }
+
+        res.json([...releases, ...prImages])
       })
     }
   }

--- a/test/container-integration.test.ts
+++ b/test/container-integration.test.ts
@@ -719,6 +719,91 @@ describe('mayara-server-signalk-plugin container integration', () => {
     })
   })
 
+  describe('GET /api/versions', () => {
+    // The route does a real `fetch` against GitHub; stub it with a
+    // URL-discriminating implementation so each test controls both sources.
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    function stubFetch(impl: (url: string) => Promise<unknown>) {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn((url: string) => impl(url))
+      )
+    }
+
+    const okJson = (body: unknown) =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(body) })
+
+    it('merges release tags and labeled open PRs, skipping unlabeled PRs', async () => {
+      stubFetch((url) => {
+        if (url.includes('/releases')) {
+          return okJson([
+            { tag_name: 'v3.4.0', prerelease: false, draft: false },
+            { tag_name: 'v3.5.0-rc1', prerelease: true, draft: false },
+            { tag_name: 'v3.3.0-draft', prerelease: false, draft: true }
+          ])
+        }
+        if (url.includes('/pulls')) {
+          return okJson([
+            { number: 123, title: 'Fix gain', labels: [{ name: 'build-image' }] },
+            { number: 99, title: 'WIP', labels: [] }
+          ])
+        }
+        return Promise.reject(new Error(`unexpected url: ${url}`))
+      })
+
+      const { router, plugin } = await loadPlugin()
+      const handler = getHandler(router, 'GET /api/versions')
+      const res = makeRes()
+      await handler({}, res)
+
+      expect(res.statusCode).toBe(200)
+      const body = res.body as { tag: string; prerelease?: boolean; pr?: number; title?: string }[]
+      expect(body).toContainEqual({ tag: 'v3.4.0', prerelease: false })
+      expect(body).toContainEqual({ tag: 'v3.5.0-rc1', prerelease: true })
+      expect(body).toContainEqual({ tag: 'pr123', pr: 123, title: 'Fix gain' })
+      // draft release filtered out
+      expect(body.some((v) => v.tag === 'v3.3.0-draft')).toBe(false)
+      // unlabeled PR filtered out
+      expect(body.some((v) => v.tag === 'pr99')).toBe(false)
+      await plugin.stop()
+    })
+
+    it('still returns releases when the PRs request fails (degrade, not fail)', async () => {
+      stubFetch((url) => {
+        if (url.includes('/releases')) {
+          return okJson([{ tag_name: 'v3.4.0', prerelease: false, draft: false }])
+        }
+        return Promise.reject(new Error('network down'))
+      })
+
+      const { router, plugin } = await loadPlugin()
+      const handler = getHandler(router, 'GET /api/versions')
+      const res = makeRes()
+      await handler({}, res)
+
+      expect(res.statusCode).toBe(200)
+      const body = res.body as { tag: string }[]
+      expect(body).toContainEqual({ tag: 'v3.4.0', prerelease: false })
+      expect(body.some((v) => v.tag.startsWith('pr'))).toBe(false)
+      await plugin.stop()
+    })
+
+    it('returns 502 when both sources are down', async () => {
+      stubFetch(() => Promise.resolve({ ok: false, json: () => Promise.resolve([]) }))
+
+      const { router, plugin } = await loadPlugin()
+      const handler = getHandler(router, 'GET /api/versions')
+      const res = makeRes()
+      await handler({}, res)
+
+      expect(res.statusCode).toBe(502)
+      await plugin.stop()
+    })
+  })
+
   describe('Signal K token integration', () => {
     it('starts in tcp: mode when no token is cached and request flow is disabled', async () => {
       const { containers, plugin } = await loadPlugin({ requestSignalkToken: false })


### PR DESCRIPTION
## Summary

- The server repo builds an ephemeral `pr<N>` Docker image when a maintainer adds the `build-image` label to a PR. Until now a tester could only run one by knowing the backend accepts arbitrary tags and there was no way to enter it — the version field is a fixed `<select>`. This surfaces those images directly in the picker.
- `/api/versions` now fetches open PRs alongside releases and returns the `build-image`-labeled ones as `{tag, pr, title}`. The two GitHub calls run via `Promise.allSettled`, so one source failing (or hitting the unauthenticated rate limit) degrades to a partial list instead of blanking the dropdown; only when both fail does it 502 (and the panel keeps its prior list).
- Only **open** PRs are listed (`state=open`), and only those carrying `build-image` — matching exactly the set whose `pr<N>` image still exists after the server-side close-cleanup. Closed/merged PRs never appear.
- The panel renders them in a fenced "PR test images" optgroup below the stable releases, and excludes `pr<N>` selections from the "update available" check.
- Deliberate non-change: `pr<N>` is not in signalk-container's floating-tag set, so it stays pinned and is **not** auto-pulled on rebuild — a tester clicks Update to fetch the newest build. A labeled-but-not-yet-built (or since-closed) PR surfaces as the normal pull error, no pre-validation added.

## Tested

- `npm run build:all` — lint, tsc, webpack, and vitest all pass (86 tests).
- New `GET /api/versions` tests: merges releases + labeled PRs while dropping draft releases and unlabeled PRs; returns releases when the PRs request fails; 502 when both sources are down.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
The plugin surfaces ephemeral per-PR Docker images in the configuration panel's version dropdown, allowing testers to select PR-specific test images tagged as `pr<N>` without manually entering tags.

## Changes

**New API endpoint `/api/versions`**
- Fetches both release tags and open GitHub PRs labeled `build-image` concurrently via the GitHub API
- Returns entries for each source in the format `{tag, pr, title}`
- Filters out draft releases and unlabeled PRs
- Uses `Promise.allSettled` for graceful degradation: returns a partial list if one source fails, returns HTTP 502 only when both sources fail
- Applies 10-second request timeouts and validates tags against the `SAFE_TAG` filter

**Configuration panel version dropdown**
- Splits version list into PR versions and release versions
- Renders PR versions in a dedicated "PR test images" optgroup below stable releases
- Excludes PR versions from the "update available" check, preventing false availability indicators
- Displays PR title text alongside version entries

**PR test image behavior**
- PR-tagged images (`pr<N>`) are intentionally excluded from the floating-tag set, keeping them pinned
- Testers must manually trigger an update to pull the latest PR build, preventing automatic upgrades
- No pre-validation for labeled-but-not-yet-built images; missing builds produce normal pull errors

**Tests**
- New test suite for `/api/versions` endpoint verifies correct merging of releases and labeled PRs, graceful degradation when PR requests fail, and 502 responses when both sources fail
- All 86 tests passing (lint, tsc, webpack, vitest)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->