### PR TITLE
ci: scope eslint type-aware linting to project sources

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,6 +28,22 @@ export default tseslint.config(
     }
   },
   {
-    ignores: ['plugin/**', 'build.js', 'public/**', 'node_modules/**']
+    // Lint only the TypeScript sources in tsconfig.eslint.json (src + test).
+    // Everything else is outside the project, so the type-aware parser
+    // (parserOptions.project) errors on it — which is what a repo-wide
+    // `eslint .` (as CodeRabbit runs) hits on the root config files and the
+    // hand-written .js config panel (bundled by webpack, not compiled by tsc,
+    // and following its own JSX style). The lint script already globs only
+    // src/test *.ts; ignore the rest here so the two stay consistent.
+    ignores: [
+      'plugin/**',
+      'public/**',
+      'node_modules/**',
+      'src/configpanel/**/*.js',
+      'build.js',
+      '**/*.config.js',
+      '**/*.config.mjs',
+      '**/*.config.ts'
+    ]
   }
 )


### PR DESCRIPTION
## Summary

- A repo-wide `eslint .` fails with a parsing error on every file outside `tsconfig.eslint.json` — the root config files (`webpack.config.js`, `prettier.config.mjs`, `vitest.config.ts`, `eslint.config.mjs`) and the hand-written `.js` config panel. Cause: `parserOptions.project` is applied to all files, so the type-aware parser errors ("file was not found in any of the provided project(s)") on anything not in the project. Our own `npm run lint` only globs `src/test *.ts`, so it never hit this — but CodeRabbit lints the whole changed tree and does.
- Fix ignores the non-project files (config-panel `.js`, `*.config.{js,mjs,ts}`, `build.js`) so they aren't fed to the typed parser. This matches the lint script's existing intent — those files are bundled by webpack / are tooling config, follow their own style, and were never meant to be linted by the TS ruleset.

Pre-existing since the strict-TypeScript conversion; surfaced by CodeRabbit on an unrelated PR that touched the panel.

## Tested

- `eslint .` (full tree, as CodeRabbit runs) is now clean — was erroring on 4+ files.
- `npm run build:all` passes (lint + tsc + webpack + vitest).