### PR TITLE
chore(release): 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "signalk-plugin-enabled-by-default": true,


### PR DESCRIPTION
Release 1.3.0 (minor — adds a feature, no breaking changes).

Since 1.2.3:

- **feat:** offer per-PR test images in the version dropdown (#60) — the config panel now lists Docker images built for open, `build-image`-labeled PRs, so a tester can pick `pr<N>` without typing the tag.
- **ci:** scope eslint type-aware linting to project sources (#61) — a repo-wide `eslint .` no longer errors on the root config files and the `.js` config panel.

After merge: tag `v1.3.0` from `main` and push the tag to trigger `publish.yml` (GitHub Release + npm trusted publishing).