### PR TITLE
chore(release): 1.4.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "1.3.0",
+  "version": "1.4.0-beta.1",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "signalk-plugin-enabled-by-default": true,


### PR DESCRIPTION
Pre-release 1.4.0-beta.1 for testing.

Since 1.3.0:

- **feat(token):** auto-recover the SignalK device token without a restart (#63) — recoverable token-request outcomes (denied/expired, device requests disabled, transient error) now re-request on the reconnect cadence, so a later approval is picked up without bouncing the plugin.

Tagging `v1.4.0-beta.1` after merge publishes to the npm `beta` dist-tag and creates a GitHub pre-release (publish.yml handles both automatically for `-beta.` tags). `latest` stays on 1.3.0.