### PR TITLE
fix(token): detect a revoked cached token and re-request

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -642,15 +642,34 @@ module.exports = function (app) {
     }
     async function ensureSignalkToken(containers, tag) {
         const dataDir = app.getDataDirPath();
-        if ((0, signalk_token_1.readCachedToken)(dataDir)) {
-            app.debug('Signal K token cached; container started with WS transport');
-            return 'done';
-        }
         // Derive scheme + port from the live SK config (same source of
         // truth as the nav transport) so a TLS-enabled server is reached
         // over https — its plain-HTTP listener 302-redirects and drops the
         // POST body, so http would never mint a token.
         const sk = resolveSignalkApi();
+        const cached = (0, signalk_token_1.readCachedToken)(dataDir);
+        if (cached) {
+            // A token on disk isn't necessarily still valid — the admin may have
+            // revoked it in Security → Access Requests. Validate before trusting
+            // it; if revoked, drop the cache and fall through to re-request so the
+            // recovery loop can pick up a fresh approval without a manual restart.
+            // `unknown` (SK still starting, network blip) keeps the cached token.
+            const state = await (0, signalk_token_1.validateCachedToken)({
+                token: cached,
+                signalkPort: sk.port,
+                ssl: sk.scheme === 'https'
+            });
+            if (state !== 'revoked') {
+                app.debug('Signal K token cached and still valid; container on WS transport');
+                return 'done';
+            }
+            app.debug('Cached Signal K token was revoked; dropping it and re-requesting');
+            (0, signalk_token_1.deleteCachedToken)(dataDir);
+            // The container is still running with the dead token in env; recreate
+            // it so it drops to tcp: until a new token is approved.
+            await containers.ensureRunning(CONTAINER_NAME, buildContainerConfig(tag));
+            app.setPluginStatus('Signal K token was revoked — re-requesting access');
+        }
         // Request `readwrite` so mayara can later push deltas back into SK
         // (radar targets, MARPA tracks, heading echoes, guard-zone
         // notifications). Today the token only reads the AIS REST snapshot,

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,9 @@ import { ConfigSchema, Config, SCHEMA_DEFAULTS } from './config/schema'
 import {
   awaitApproval,
   beginTokenRequest,
+  deleteCachedToken,
   readCachedToken,
+  validateCachedToken,
   writeCachedToken
 } from './signalk-token'
 
@@ -746,16 +748,36 @@ module.exports = function (app: MayaraServerAPI): Plugin {
     tag: string
   ): Promise<TokenOutcome> {
     const dataDir = app.getDataDirPath()
-    if (readCachedToken(dataDir)) {
-      app.debug('Signal K token cached; container started with WS transport')
-      return 'done'
-    }
 
     // Derive scheme + port from the live SK config (same source of
     // truth as the nav transport) so a TLS-enabled server is reached
     // over https — its plain-HTTP listener 302-redirects and drops the
     // POST body, so http would never mint a token.
     const sk = resolveSignalkApi()
+
+    const cached = readCachedToken(dataDir)
+    if (cached) {
+      // A token on disk isn't necessarily still valid — the admin may have
+      // revoked it in Security → Access Requests. Validate before trusting
+      // it; if revoked, drop the cache and fall through to re-request so the
+      // recovery loop can pick up a fresh approval without a manual restart.
+      // `unknown` (SK still starting, network blip) keeps the cached token.
+      const state = await validateCachedToken({
+        token: cached,
+        signalkPort: sk.port,
+        ssl: sk.scheme === 'https'
+      })
+      if (state !== 'revoked') {
+        app.debug('Signal K token cached and still valid; container on WS transport')
+        return 'done'
+      }
+      app.debug('Cached Signal K token was revoked; dropping it and re-requesting')
+      deleteCachedToken(dataDir)
+      // The container is still running with the dead token in env; recreate
+      // it so it drops to tcp: until a new token is approved.
+      await containers.ensureRunning(CONTAINER_NAME, buildContainerConfig(tag))
+      app.setPluginStatus('Signal K token was revoked — re-requesting access')
+    }
     // Request `readwrite` so mayara can later push deltas back into SK
     // (radar targets, MARPA tracks, heading echoes, guard-zone
     // notifications). Today the token only reads the AIS REST snapshot,

--- a/src/signalk-token.ts
+++ b/src/signalk-token.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from 'fs'
+import { existsSync, readFileSync, writeFileSync, rmSync } from 'fs'
 import { join } from 'path'
 import { request as httpsRequest } from 'https'
 
@@ -37,12 +37,17 @@ interface JsonResponse {
 async function requestJson(
   method: 'GET' | 'POST',
   url: string,
-  body: string | undefined
+  body: string | undefined,
+  extraHeaders?: Record<string, string>
 ): Promise<JsonResponse> {
+  const headers: Record<string, string> = { ...extraHeaders }
+  if (body !== undefined) headers['Content-Type'] = 'application/json'
+  const hasHeaders = Object.keys(headers).length > 0
+
   if (!url.startsWith('https:')) {
     const res = await fetch(url, {
       method,
-      headers: body !== undefined ? { 'Content-Type': 'application/json' } : undefined,
+      headers: hasHeaders ? headers : undefined,
       body
     })
     return { status: res.status, ok: res.ok, json: () => res.json() }
@@ -54,7 +59,7 @@ async function requestJson(
       {
         method,
         rejectUnauthorized: false,
-        headers: body !== undefined ? { 'Content-Type': 'application/json' } : undefined
+        headers: hasHeaders ? headers : undefined
       },
       (res) => {
         const chunks: Buffer[] = []
@@ -133,6 +138,47 @@ export function hasCachedToken(dataDir: string): boolean {
 export function writeCachedToken(dataDir: string, token: string): void {
   const path = join(dataDir, TOKEN_FILENAME)
   writeFileSync(path, token, { mode: 0o600 })
+}
+
+/** Remove the cached token (e.g. after the server revoked it). No-op if absent. */
+export function deleteCachedToken(dataDir: string): void {
+  rmSync(join(dataDir, TOKEN_FILENAME), { force: true })
+}
+
+export interface ValidateOptions {
+  token: string
+  signalkPort: number
+  ssl: boolean
+}
+
+/**
+ * Check whether a cached token is still accepted by the local Signal K
+ * server. Returns:
+ *   - `valid`   — the server accepted the bearer (HTTP 2xx)
+ *   - `revoked` — the server rejected it (HTTP 401/403): the admin revoked
+ *                 or it expired, so the cache should be dropped and re-requested
+ *   - `unknown` — could not tell (network error, SK still starting, other
+ *                 status). Treated as "keep using it" so a transient blip
+ *                 doesn't throw away a good token.
+ *
+ * Hits `/signalk/v1/api/vessels/self` — a read every approved device token
+ * may perform — over the same loopback transport the token flow uses.
+ */
+export async function validateCachedToken(
+  opts: ValidateOptions
+): Promise<'valid' | 'revoked' | 'unknown'> {
+  const scheme = opts.ssl ? 'https' : 'http'
+  const url = `${scheme}://127.0.0.1:${opts.signalkPort}/signalk/v1/api/vessels/self`
+  try {
+    const res = await requestJson('GET', url, undefined, {
+      Authorization: `Bearer ${opts.token}`
+    })
+    if (res.status === 401 || res.status === 403) return 'revoked'
+    if (res.ok) return 'valid'
+    return 'unknown'
+  } catch {
+    return 'unknown'
+  }
 }
 
 interface AccessRequestReply {

--- a/test/container-integration.test.ts
+++ b/test/container-integration.test.ts
@@ -56,6 +56,10 @@ vi.mock('../src/signalk-token', async () => {
     ...actual,
     readCachedToken: vi.fn(() => undefined),
     writeCachedToken: vi.fn(),
+    deleteCachedToken: vi.fn(),
+    // Default: a cached token (when present) validates fine, so existing
+    // tests are unaffected. Revocation tests override per-call.
+    validateCachedToken: vi.fn(() => Promise.resolve('valid' as const)),
     beginTokenRequest: vi.fn(() =>
       Promise.resolve({ kind: 'error' as const, message: 'stubbed in tests' })
     ),
@@ -370,6 +374,8 @@ beforeEach(async () => {
   const tokenModule = await loadTokenMock()
   vi.mocked(tokenModule.readCachedToken).mockReset().mockReturnValue(undefined)
   vi.mocked(tokenModule.writeCachedToken).mockReset()
+  vi.mocked(tokenModule.deleteCachedToken).mockReset()
+  vi.mocked(tokenModule.validateCachedToken).mockReset().mockResolvedValue('valid')
   vi.mocked(tokenModule.beginTokenRequest)
     .mockReset()
     .mockResolvedValue({ kind: 'error', message: 'stubbed in tests' })
@@ -1052,6 +1058,40 @@ describe('mayara-server-signalk-plugin container integration', () => {
       // No further attempts should accrue after stop() flips the cancel flag.
       await new Promise<void>((resolve) => setTimeout(resolve, 80))
       expect(vi.mocked(tokenModule.beginTokenRequest).mock.calls.length).toBe(countAfterStop)
+    })
+
+    it('drops a revoked cached token and re-requests', async () => {
+      const tokenModule = await loadTokenMock()
+      // A token is on disk, but the server has revoked it.
+      vi.mocked(tokenModule.readCachedToken).mockReturnValue('revoked-jwt')
+      vi.mocked(tokenModule.validateCachedToken).mockResolvedValue('revoked')
+      vi.mocked(tokenModule.beginTokenRequest).mockResolvedValue({
+        kind: 'pending',
+        requestId: 'r-1',
+        href: '/signalk/v1/requests/r-1'
+      })
+
+      const { plugin, app } = await loadPlugin({ requestSignalkToken: true })
+
+      // The dead token is dropped and a fresh request is issued rather than
+      // the plugin trusting the cache forever.
+      expect(tokenModule.deleteCachedToken).toHaveBeenCalledTimes(1)
+      expect(tokenModule.beginTokenRequest).toHaveBeenCalledTimes(1)
+      expect(app.setPluginStatus).toHaveBeenCalledWith(expect.stringContaining('revoked'))
+      await plugin.stop()
+    })
+
+    it('keeps a valid cached token without re-requesting', async () => {
+      const tokenModule = await loadTokenMock()
+      vi.mocked(tokenModule.readCachedToken).mockReturnValue('good-jwt')
+      vi.mocked(tokenModule.validateCachedToken).mockResolvedValue('valid')
+
+      const { plugin } = await loadPlugin({ requestSignalkToken: true })
+
+      // A still-valid token short-circuits: no delete, no new request.
+      expect(tokenModule.deleteCachedToken).not.toHaveBeenCalled()
+      expect(tokenModule.beginTokenRequest).not.toHaveBeenCalled()
+      await plugin.stop()
     })
   })
 

--- a/test/signalk-token.test.ts
+++ b/test/signalk-token.test.ts
@@ -15,7 +15,9 @@ vi.mock('https', () => ({ request: httpsRequestMock }))
 import {
   awaitApproval,
   beginTokenRequest,
+  deleteCachedToken,
   readCachedToken,
+  validateCachedToken,
   writeCachedToken
 } from '../src/signalk-token'
 
@@ -97,6 +99,52 @@ describe('signalk-token: cache helpers', () => {
       const mode = statSync(path).mode & 0o777
       expect(mode).toBe(0o600)
     }
+  })
+
+  it('deleteCachedToken removes the file and is a no-op when absent', () => {
+    const path = join(dataDir, 'signalk-token')
+    writeCachedToken(dataDir, 'eyJabc.def')
+    deleteCachedToken(dataDir)
+    expect(existsSync(path)).toBe(false)
+    // Second call must not throw.
+    expect(() => {
+      deleteCachedToken(dataDir)
+    }).not.toThrow()
+  })
+})
+
+describe('signalk-token: validateCachedToken', () => {
+  it('returns revoked on HTTP 401', async () => {
+    globalThis.fetch = vi.fn(() => Promise.resolve(makeFetchResponse(401, {})))
+    const state = await validateCachedToken({ token: 't', signalkPort: 3000, ssl: false })
+    expect(state).toBe('revoked')
+  })
+
+  it('returns revoked on HTTP 403', async () => {
+    globalThis.fetch = vi.fn(() => Promise.resolve(makeFetchResponse(403, {})))
+    const state = await validateCachedToken({ token: 't', signalkPort: 3000, ssl: false })
+    expect(state).toBe('revoked')
+  })
+
+  it('returns valid on HTTP 200 and sends the bearer token', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(makeFetchResponse(200, { mmsi: '123' })))
+    globalThis.fetch = fetchMock
+    const state = await validateCachedToken({ token: 'the-tok', signalkPort: 3000, ssl: false })
+    expect(state).toBe('valid')
+    const init = fetchMock.mock.calls[0][1] as RequestInit
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer the-tok')
+  })
+
+  it('returns unknown on a network error (keeps the cached token)', async () => {
+    globalThis.fetch = vi.fn(() => Promise.reject(new Error('ECONNREFUSED')))
+    const state = await validateCachedToken({ token: 't', signalkPort: 3000, ssl: false })
+    expect(state).toBe('unknown')
+  })
+
+  it('returns unknown on an unexpected status (e.g. 500)', async () => {
+    globalThis.fetch = vi.fn(() => Promise.resolve(makeFetchResponse(500, {})))
+    const state = await validateCachedToken({ token: 't', signalkPort: 3000, ssl: false })
+    expect(state).toBe('unknown')
   })
 })
 


### PR DESCRIPTION
## Summary

The plugin trusted the on-disk SignalK token indefinitely — `ensureSignalkToken` returned early on any cached token without checking it was still valid. If the admin revoked it in Security → Access Requests, mayara kept running with the dead token on its `ws:` upstream (SK rejects it with 401), the authenticated AIS seed silently failed, and nothing recovered until a manual plugin restart. (Found while testing the upstream-status work against a deliberately revoked token.)

- Validate the cached token against the local SK on start (`validateCachedToken` → `valid`/`revoked`/`unknown`).
- On `revoked` (401/403): drop the cache, recreate the container so it falls back to `tcp:` until re-approved, and re-request via the existing recovery loop (#63) so a fresh approval is picked up without a restart.
- `unknown` (network blip, SK still starting) keeps the cached token — a transient outage never discards a good token.

Pairs with the mayara-server side (MarineYachtRadar/mayara-server #326), which now reports nav freshness and clears the stale heading so the GUI shows "navigation lost" instead of a frozen value.

## Tested

- `npm run build:all` — lint + tsc + webpack + vitest, 96 tests pass.
- New unit tests: `validateCachedToken` returns revoked/valid/unknown for 401/403, 200 (with the bearer header asserted), network error, and 500; `deleteCachedToken` removes the file and no-ops when absent.
- New integration tests: a revoked cached token is dropped and a fresh request issued; a valid cached token short-circuits with no delete/re-request.