### PR TITLE
chore(release): 1.4.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "signalk-plugin-enabled-by-default": true,


### PR DESCRIPTION
Pre-release 1.4.0-beta.2 for testing.

Since 1.4.0-beta.1:

- **fix(token):** detect a revoked cached SignalK token and re-request (#65) — the plugin now validates the cached token on start; if the admin revoked it, the cache is dropped, the container falls back to `tcp:`, and a fresh request is issued via the recovery loop (no manual restart needed).

Tagging `v1.4.0-beta.2` after merge publishes to the npm `beta` dist-tag and creates a GitHub pre-release. `latest` stays on 1.3.0.