### PR TITLE
fix(token): prevent duplicate access requests on fast restart

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -50,8 +50,14 @@ module.exports = function (app) {
     // how many radars are discovered.
     let notificationForwarder = null;
     let discoveryInterval = null;
-    // Set true on stop() so the in-flight token poller exits its loop.
-    let tokenPollerCancelled = false;
+    // Monotonic generation for the token-acquisition loop. Bumped on every
+    // start() and stop(); each recovery loop captures the value at launch and
+    // treats itself as cancelled once it no longer matches. A boolean flag was
+    // insufficient: a fast stop()→start() reset it to false under an old
+    // in-flight loop, which then resumed and POSTed a duplicate access request
+    // alongside the new loop. A counter makes a superseded loop stay cancelled
+    // forever, so only one acquisition is ever live.
+    let tokenGeneration = 0;
     let reconnectInterval = null;
     let isConnected = false;
     // Appended to the "Connected" status line when a newer container image
@@ -78,19 +84,20 @@ module.exports = function (app) {
             // every field being present.
             const merged = { ...schema_1.SCHEMA_DEFAULTS, ...config };
             currentSettings = merged;
-            // Reset the poller cancel flag so a stop/start cycle (config
-            // change, plugin disable/enable) lets the next start make a
-            // fresh token request.
-            tokenPollerCancelled = false;
+            // New generation: supersedes any token loop left over from a prior
+            // start (a fast disable/enable or config save) so only the loop this
+            // start launches is live.
+            tokenGeneration++;
             void asyncStart(merged).catch((err) => {
                 app.setPluginError(`Startup failed: ${err instanceof Error ? err.message : String(err)}`);
             });
         },
         async stop() {
             app.debug('Stopping mayara-server-signalk-plugin');
-            // Tell any in-flight token poller to exit on its next tick so
-            // it doesn't keep the process alive after stop() returns.
-            tokenPollerCancelled = true;
+            // Bump the generation so any in-flight token loop sees itself as
+            // superseded and exits on its next check, without keeping the process
+            // alive after stop() returns.
+            tokenGeneration++;
             try {
                 app.radarApi.unRegister(PLUGIN_ID);
             }
@@ -640,7 +647,7 @@ module.exports = function (app) {
         }
         return config;
     }
-    async function ensureSignalkToken(containers, tag) {
+    async function ensureSignalkToken(containers, tag, isCancelled = () => false) {
         const dataDir = app.getDataDirPath();
         // Derive scheme + port from the live SK config (same source of
         // truth as the nav transport) so a TLS-enabled server is reached
@@ -704,6 +711,13 @@ module.exports = function (app) {
                     'Security settings, or add `--signalk-token <token>` to mayaraArgs.');
                 // Recoverable: the operator may enable device requests later.
                 return 'retry';
+            case 'already-pending':
+                // A request for this clientId is already outstanding on SK (e.g. one
+                // left by a prior plugin instance). Don't POST another — wait and let
+                // the recovery loop re-check; once it's approved the token caches and
+                // the next pass returns 'done'.
+                app.setPluginStatus('Awaiting Signal K token approval — see Security → Access Requests');
+                return 'retry';
             case 'error':
                 app.debug(`Signal K token request error: ${begin.message}`);
                 return 'retry';
@@ -714,15 +728,15 @@ module.exports = function (app) {
         app.setPluginStatus('Awaiting Signal K token approval — see Security → Access Requests');
         app.debug(`Awaiting approval at ${begin.href} (request ${begin.requestId}). ` +
             `Set plugin config "requestSignalkToken" to false to suppress this.`);
-        const token = await (0, signalk_token_1.awaitApproval)(begin.href, sk.port, () => tokenPollerCancelled, (msg) => {
+        const token = await (0, signalk_token_1.awaitApproval)(begin.href, sk.port, isCancelled, (msg) => {
             app.debug(msg);
         }, undefined, // keep the default poll interval
         sk.scheme === 'https');
         if (!token) {
-            // Denied, expired, or plugin stopped. Leave the container on its
-            // existing transport. If we weren't stopped, this is recoverable —
-            // the operator may approve a fresh request later.
-            if (tokenPollerCancelled) {
+            // Denied, expired, or superseded. Leave the container on its existing
+            // transport. If we weren't superseded, this is recoverable — the
+            // operator may approve a fresh request later.
+            if (isCancelled()) {
                 return 'done';
             }
             app.setPluginStatus('Signal K token request was denied or expired. AIS overlay will ' +
@@ -747,22 +761,27 @@ module.exports = function (app) {
      * approves the device request (or enables device access requests) later is
      * picked up without a plugin restart. Each attempt that returns `retry`
      * waits `recoveryMs` before the next, capped at `MAX_TOKEN_RECOVERY_ATTEMPTS`
-     * so a permanently-denied install doesn't poll forever. The shared
-     * `tokenPollerCancelled` flag (set by `stop()`) ends the loop promptly so it
-     * never outlives the plugin.
+     * so a permanently-denied install doesn't poll forever.
+     *
+     * The loop captures the token generation at launch and stops the moment a
+     * later start()/stop() supersedes it — guaranteeing exactly one live
+     * acquisition, so a fast restart can't leave two loops POSTing duplicate
+     * access requests.
      */
     async function ensureSignalkTokenWithRecovery(containers, tag, recoveryMs) {
+        const myGeneration = tokenGeneration;
+        const isCancelled = () => myGeneration !== tokenGeneration;
         const MAX_TOKEN_RECOVERY_ATTEMPTS = 60;
         for (let attempt = 0; attempt < MAX_TOKEN_RECOVERY_ATTEMPTS; attempt++) {
-            if (tokenPollerCancelled) {
+            if (isCancelled()) {
                 return;
             }
-            const outcome = await ensureSignalkToken(containers, tag);
+            const outcome = await ensureSignalkToken(containers, tag, isCancelled);
             if (outcome === 'done') {
                 return;
             }
-            // Recoverable failure: wait, then re-attempt — unless we were stopped
-            // while waiting.
+            // Recoverable failure: wait, then re-attempt — unless superseded while
+            // waiting (re-checked at the top of the loop).
             await new Promise((resolve) => setTimeout(resolve, recoveryMs));
         }
         app.debug('Signal K token recovery gave up after repeated failures; restart the plugin to retry');

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,8 +73,14 @@ module.exports = function (app: MayaraServerAPI): Plugin {
   // how many radars are discovered.
   let notificationForwarder: NotificationForwarder | null = null
   let discoveryInterval: ReturnType<typeof setInterval> | null = null
-  // Set true on stop() so the in-flight token poller exits its loop.
-  let tokenPollerCancelled = false
+  // Monotonic generation for the token-acquisition loop. Bumped on every
+  // start() and stop(); each recovery loop captures the value at launch and
+  // treats itself as cancelled once it no longer matches. A boolean flag was
+  // insufficient: a fast stop()→start() reset it to false under an old
+  // in-flight loop, which then resumed and POSTed a duplicate access request
+  // alongside the new loop. A counter makes a superseded loop stay cancelled
+  // forever, so only one acquisition is ever live.
+  let tokenGeneration = 0
   let reconnectInterval: ReturnType<typeof setInterval> | null = null
   let isConnected = false
   // Appended to the "Connected" status line when a newer container image
@@ -104,10 +110,10 @@ module.exports = function (app: MayaraServerAPI): Plugin {
       // every field being present.
       const merged: Config = { ...SCHEMA_DEFAULTS, ...config }
       currentSettings = merged
-      // Reset the poller cancel flag so a stop/start cycle (config
-      // change, plugin disable/enable) lets the next start make a
-      // fresh token request.
-      tokenPollerCancelled = false
+      // New generation: supersedes any token loop left over from a prior
+      // start (a fast disable/enable or config save) so only the loop this
+      // start launches is live.
+      tokenGeneration++
       void asyncStart(merged).catch((err: unknown) => {
         app.setPluginError(`Startup failed: ${err instanceof Error ? err.message : String(err)}`)
       })
@@ -116,9 +122,10 @@ module.exports = function (app: MayaraServerAPI): Plugin {
     async stop() {
       app.debug('Stopping mayara-server-signalk-plugin')
 
-      // Tell any in-flight token poller to exit on its next tick so
-      // it doesn't keep the process alive after stop() returns.
-      tokenPollerCancelled = true
+      // Bump the generation so any in-flight token loop sees itself as
+      // superseded and exits on its next check, without keeping the process
+      // alive after stop() returns.
+      tokenGeneration++
 
       try {
         app.radarApi.unRegister(PLUGIN_ID)
@@ -745,7 +752,8 @@ module.exports = function (app: MayaraServerAPI): Plugin {
 
   async function ensureSignalkToken(
     containers: ContainerManagerApi,
-    tag: string
+    tag: string,
+    isCancelled: () => boolean = () => false
   ): Promise<TokenOutcome> {
     const dataDir = app.getDataDirPath()
 
@@ -816,6 +824,13 @@ module.exports = function (app: MayaraServerAPI): Plugin {
         )
         // Recoverable: the operator may enable device requests later.
         return 'retry'
+      case 'already-pending':
+        // A request for this clientId is already outstanding on SK (e.g. one
+        // left by a prior plugin instance). Don't POST another — wait and let
+        // the recovery loop re-check; once it's approved the token caches and
+        // the next pass returns 'done'.
+        app.setPluginStatus('Awaiting Signal K token approval — see Security → Access Requests')
+        return 'retry'
       case 'error':
         app.debug(`Signal K token request error: ${begin.message}`)
         return 'retry'
@@ -833,7 +848,7 @@ module.exports = function (app: MayaraServerAPI): Plugin {
     const token = await awaitApproval(
       begin.href,
       sk.port,
-      () => tokenPollerCancelled,
+      isCancelled,
       (msg) => {
         app.debug(msg)
       },
@@ -841,10 +856,10 @@ module.exports = function (app: MayaraServerAPI): Plugin {
       sk.scheme === 'https'
     )
     if (!token) {
-      // Denied, expired, or plugin stopped. Leave the container on its
-      // existing transport. If we weren't stopped, this is recoverable —
-      // the operator may approve a fresh request later.
-      if (tokenPollerCancelled) {
+      // Denied, expired, or superseded. Leave the container on its existing
+      // transport. If we weren't superseded, this is recoverable — the
+      // operator may approve a fresh request later.
+      if (isCancelled()) {
         return 'done'
       }
       app.setPluginStatus(
@@ -874,26 +889,31 @@ module.exports = function (app: MayaraServerAPI): Plugin {
    * approves the device request (or enables device access requests) later is
    * picked up without a plugin restart. Each attempt that returns `retry`
    * waits `recoveryMs` before the next, capped at `MAX_TOKEN_RECOVERY_ATTEMPTS`
-   * so a permanently-denied install doesn't poll forever. The shared
-   * `tokenPollerCancelled` flag (set by `stop()`) ends the loop promptly so it
-   * never outlives the plugin.
+   * so a permanently-denied install doesn't poll forever.
+   *
+   * The loop captures the token generation at launch and stops the moment a
+   * later start()/stop() supersedes it — guaranteeing exactly one live
+   * acquisition, so a fast restart can't leave two loops POSTing duplicate
+   * access requests.
    */
   async function ensureSignalkTokenWithRecovery(
     containers: ContainerManagerApi,
     tag: string,
     recoveryMs: number
   ): Promise<void> {
+    const myGeneration = tokenGeneration
+    const isCancelled = () => myGeneration !== tokenGeneration
     const MAX_TOKEN_RECOVERY_ATTEMPTS = 60
     for (let attempt = 0; attempt < MAX_TOKEN_RECOVERY_ATTEMPTS; attempt++) {
-      if (tokenPollerCancelled) {
+      if (isCancelled()) {
         return
       }
-      const outcome = await ensureSignalkToken(containers, tag)
+      const outcome = await ensureSignalkToken(containers, tag, isCancelled)
       if (outcome === 'done') {
         return
       }
-      // Recoverable failure: wait, then re-attempt — unless we were stopped
-      // while waiting.
+      // Recoverable failure: wait, then re-attempt — unless superseded while
+      // waiting (re-checked at the top of the loop).
       await new Promise<void>((resolve) => setTimeout(resolve, recoveryMs))
     }
     app.debug(

--- a/src/signalk-token.ts
+++ b/src/signalk-token.ts
@@ -86,6 +86,10 @@ export type EnsureResult =
   | { kind: 'no-security' }
   | { kind: 'requests-disabled' }
   | { kind: 'pending'; requestId: string; href: string }
+  // SK already has a PENDING request for this clientId (it rejects a second
+  // one with HTTP 400). Don't POST again — wait for the existing request to
+  // be approved or expire.
+  | { kind: 'already-pending' }
   | { kind: 'error'; message: string }
 
 export interface EnsureOptions {
@@ -240,6 +244,16 @@ export async function beginTokenRequest(opts: EnsureOptions): Promise<EnsureResu
   }
   if (res.status === 403) {
     return { kind: 'requests-disabled' }
+  }
+  if (res.status === 400) {
+    // SK rejects a second pending request for the same clientId with 400
+    // ("...has already requested access"). Treat as already-pending so the
+    // caller waits instead of erroring or POSTing again.
+    const reply = (await res.json().catch(() => undefined)) as { message?: string } | undefined
+    if (reply?.message?.includes('already requested')) {
+      return { kind: 'already-pending' }
+    }
+    return { kind: 'error', message: reply?.message ?? 'HTTP 400 from access-request endpoint' }
   }
   if (res.status !== 202 && res.status !== 200) {
     return { kind: 'error', message: `Unexpected HTTP ${res.status} from access-request endpoint` }

--- a/test/container-integration.test.ts
+++ b/test/container-integration.test.ts
@@ -1093,6 +1093,74 @@ describe('mayara-server-signalk-plugin container integration', () => {
       expect(tokenModule.beginTokenRequest).not.toHaveBeenCalled()
       await plugin.stop()
     })
+
+    it('does not POST again when SK reports a request already pending', async () => {
+      const tokenModule = await loadTokenMock()
+      vi.mocked(tokenModule.beginTokenRequest).mockResolvedValue({
+        kind: 'already-pending'
+      })
+
+      const { plugin, app } = await loadPlugin({
+        requestSignalkToken: true,
+        reconnectInterval: 0.01
+      })
+      // It surfaces "awaiting approval" and waits — it does NOT call
+      // awaitApproval on a non-existent href, and recovery just re-checks.
+      expect(app.setPluginStatus).toHaveBeenCalledWith(
+        expect.stringContaining('Awaiting Signal K token approval')
+      )
+      expect(tokenModule.awaitApproval).not.toHaveBeenCalled()
+      await plugin.stop()
+    })
+
+    it('a token loop superseded by stop()+start() does not keep requesting', async () => {
+      const tokenModule = await loadTokenMock()
+      // The first loop opens a request and blocks in awaitApproval until its
+      // generation is cancelled — modelling an admin who hasn't approved yet.
+      vi.mocked(tokenModule.beginTokenRequest).mockResolvedValue({
+        kind: 'pending',
+        requestId: 'r-1',
+        href: '/signalk/v1/requests/r-1'
+      })
+      vi.mocked(tokenModule.awaitApproval).mockImplementation(
+        (_href, _port, isCancelled: () => boolean) =>
+          new Promise((resolve) => {
+            const timer = setInterval(() => {
+              if (isCancelled()) {
+                clearInterval(timer)
+                resolve(undefined)
+              }
+            }, 5)
+          })
+      )
+
+      const { plugin, app } = await loadPlugin({
+        requestSignalkToken: true,
+        reconnectInterval: 0.01
+      })
+
+      // Restart: stop() then start() bump the generation twice. The original
+      // loop's awaitApproval is now cancelled and must not resume/re-POST.
+      await plugin.stop()
+      const callsAfterRestart = vi.mocked(tokenModule.beginTokenRequest).mock.calls.length
+      plugin.start({
+        managedContainer: true,
+        mayaraVersion: 'latest',
+        mayaraArgs: [],
+        requestSignalkToken: false, // the new generation doesn't request
+        host: 'localhost',
+        port: 6502,
+        secure: false,
+        discoveryPollInterval: 10,
+        reconnectInterval: 5
+      })
+      await new Promise((resolve) => setTimeout(resolve, 80))
+
+      // The superseded loop exited rather than looping into more POSTs.
+      expect(vi.mocked(tokenModule.beginTokenRequest).mock.calls.length).toBe(callsAfterRestart)
+      void app
+      await plugin.stop()
+    })
   })
 
   describe('GUI reverse proxy mount', () => {

--- a/test/signalk-token.test.ts
+++ b/test/signalk-token.test.ts
@@ -184,6 +184,36 @@ describe('signalk-token: beginTokenRequest', () => {
     expect(result).toEqual({ kind: 'requests-disabled' })
   })
 
+  it('returns kind=already-pending on SK 400 "already requested"', async () => {
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve(
+        makeFetchResponse(400, {
+          message: "A device with clientId 'test' has already requested access"
+        })
+      )
+    )
+    const result = await beginTokenRequest({
+      dataDir,
+      signalkPort: 3000,
+      clientId: 'test',
+      description: 'test'
+    })
+    expect(result).toEqual({ kind: 'already-pending' })
+  })
+
+  it('returns kind=error on a 400 that is not the already-pending message', async () => {
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve(makeFetchResponse(400, { message: 'bad request' }))
+    )
+    const result = await beginTokenRequest({
+      dataDir,
+      signalkPort: 3000,
+      clientId: 'test',
+      description: 'test'
+    })
+    expect(result.kind).toBe('error')
+  })
+
   it('returns kind=pending with the href when SK accepts the request', async () => {
     globalThis.fetch = vi.fn(() =>
       Promise.resolve(


### PR DESCRIPTION
## Summary

Reproduced live: delete the SK token, restart the SK server, approve the new request — and a *second* access request fires moments later, leaving one approved device plus one orphan pending request. SK rejects approving the orphan (the clientId is already an approved device), so mayara sits disconnected until it self-recovers.

Root cause: token acquisition used a shared `tokenPollerCancelled` boolean. A fast `stop()`→`start()` (config save / disable-enable, or the restart sequence above) reset it to `false` under an in-flight recovery loop, which then resumed past its cancel check and POSTed a fresh request — concurrently with the loop the new `start()` launched.

- Replace the boolean with a monotonic **generation counter** bumped on every `start()`/`stop()`. Each loop captures its generation at launch and is cancelled the moment it's superseded, so exactly one acquisition is ever live — a restart can't strand a second one. This also neutralises the previously-uncleared recovery `setTimeout` (it exits on the next generation check).
- Map SK's **400 "already requested"** to a new `already-pending` outcome so the plugin waits for the existing request rather than erroring or POSTing again (defense-in-depth for a request left by a prior instance).

Found while testing the upstream-status / revoked-token work (beta.2). Targets the same `1.4.0` line.

## Tested

- `npm run build:all` — lint + tsc + webpack + vitest, 100 tests pass.
- New unit tests: `beginTokenRequest` returns `already-pending` on SK's 400 "already requested", and `error` on other 400s.
- New integration tests: an `already-pending` result waits (no `awaitApproval`, no re-POST); a token loop superseded by `stop()`+`start()` does not keep requesting.