### PR TITLE
chore(release): 1.4.0-beta.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "1.4.0-beta.2",
+  "version": "1.4.0-beta.3",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "signalk-plugin-enabled-by-default": true,


### PR DESCRIPTION
Pre-release 1.4.0-beta.3 for testing.

Since 1.4.0-beta.2:

- **fix(token):** prevent duplicate access requests on fast restart (#67) — a generation counter now supersedes any leftover token loop on stop()/start(), so a quick SK restart can no longer leave one approved + one orphan pending request. Also reuses an existing pending request instead of POSTing a duplicate.

Tagging `v1.4.0-beta.3` after merge publishes to the npm `beta` dist-tag and creates a GitHub pre-release. `latest` stays on 1.3.0.