### PR TITLE
fix(deps): drop signalk-container npm peer dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,7 @@ The mayara GUI is proxied through Signal K at `/plugins/<id>/gui/` so only the S
 ## Dependencies
 
 - Signal K Server ≥ 2.24.0 (Radar API requirement)
-- signalk-container ≥ 1.6.0 (declared in `peerDependenciesMeta` as optional and in `signalk.requires`)
+- signalk-container ≥ 1.6.0 (declared in `signalk.requires`; intentionally **not** an npm `peerDependency`. It's a cross-plugin runtime dependency discovered at runtime via `globalThis.__signalk_containerManager` and installed through Signal K's appstore, not something npm should resolve. Declaring it as a peer made npm enforce the version range, which broke `@beta`/prerelease installs with ERESOLVE because npm excludes prereleases from plain `>=` ranges.)
 - Node ≥ engines floor in `package.json` (CI matrix tests Node 22 and 24)
 
 When bumping the Node engines floor, update **all** of: `package.json` engines, `package.json` `@types/node`, `.github/dependabot.yml` comment, and the README prerequisites line.

--- a/package.json
+++ b/package.json
@@ -51,14 +51,6 @@
     "http-proxy-middleware": "^3.0.5",
     "ws": "^8.14.0"
   },
-  "peerDependencies": {
-    "signalk-container": ">=1.9.0"
-  },
-  "peerDependenciesMeta": {
-    "signalk-container": {
-      "optional": true
-    }
-  },
   "devDependencies": {
     "@babel/core": "^7.29.0",
     "@babel/preset-react": "^7.28.5",


### PR DESCRIPTION
## Summary

Installing the plugin alongside a prerelease of signalk-container failed with `ERESOLVE`: the plugin declared `signalk-container >=1.9.0` as an (optional) npm peer, and npm excludes prereleases from plain `>=` ranges — so `signalk-container@1.13.0-beta.1` didn't satisfy the peer and the whole install aborted (only `--legacy-peer-deps` got past it).

signalk-container is a **cross-plugin runtime dependency** discovered at runtime via `globalThis.__signalk_containerManager` and installed through Signal K's appstore — npm should never have been resolving it. Remove the `peerDependencies`/`peerDependenciesMeta` entries; it remains declared via `signalk.requires`, which is the correct Signal K mechanism and unaffected.

## Tested

- `npm run build:all` green (100 tests); `signalk.requires` still lists signalk-container.
- Reproduced the original `ERESOLVE` on `npm install signalk-container@beta`; with the peer removed a plain install resolves the prerelease without `--legacy-peer-deps`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Removes the `signalk-container` npm peer dependency declaration to resolve npm resolution failures with prerelease versions.

The plugin previously declared `signalk-container >=1.9.0` as an optional peer dependency, causing `ERESOLVE` errors during installation when prerelease versions (e.g., `signalk-container@1.13.0-beta.1`) were present, as npm excludes prereleases from plain `>=` ranges. Since `signalk-container` is a cross-plugin runtime dependency discovered at runtime via `globalThis.__signalk_containerManager` and installed through Signal K's appstore, npm should not be resolving it.

**Changes:**
- `package.json`: Removes `peerDependencies` and `peerDependenciesMeta` entries for `signalk-container`
- `AGENTS.md`: Updates documentation to clarify that `signalk-container >= 1.6.0` is intentionally not an npm peer dependency

The runtime dependency declaration via `signalk.requires` remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->