### PR TITLE
chore(release): 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "1.4.0-beta.3",
+  "version": "1.4.0",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "signalk-plugin-enabled-by-default": true,


### PR DESCRIPTION
Stable release 1.4.0, promoting the 1.4.0-beta line to `latest` after testing out.

Since 1.3.0:

- **feat(token):** auto-recover the SignalK device token without a restart (#63)
- **fix(token):** detect a revoked cached token and re-request (#65)
- **fix(token):** prevent duplicate access requests on fast restart (#67)
- **fix(deps):** drop signalk-container npm peer dependency — fixes ERESOLVE on prerelease installs (#70)
- **docs:** update Signal K auth section for resilient token handling (#69)

Together these make the Signal K device-token flow resilient: the plugin requests a token automatically, validates the cached one on start, and re-requests without a restart if it's denied, revoked, or expires — without ever leaving a duplicate/orphan access request.

Tagging `v1.4.0` after merge publishes to npm `latest` and creates a GitHub release.