### PR TITLE
chore(release): 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "signalk-plugin-enabled-by-default": true,


### PR DESCRIPTION
## Summary

Patch release. Ships the one fix merged since v1.4.0:

- **#72** `fix(proxy): forward /v2 API paths to mayara through the GUI proxy` — the GUI proxy now passes mayara's `/v2/...` API (recordings, debug panel) straight through instead of treating it as a static asset, so the Recordings page no longer 404s behind the Signal K proxy.

Only `package.json` is bumped (1.4.0 → 1.4.1). Tag `v1.4.1` after merge to trigger publish.