### PR TITLE
feat(webapp): use radar logo as favicon on redirect page

### DIFF
--- a/build.js
+++ b/build.js
@@ -42,6 +42,7 @@ function main() {
 <head>
   <meta charset="utf-8">
   <title>MaYaRa Radar</title>
+  <link rel="icon" type="image/png" href="assets/mayara_logo.png">
   <script>
     window.location.replace('/plugins/mayara-server-signalk-plugin/gui/');
   </script>


### PR DESCRIPTION
## Summary

- The generated `public/index.html` redirect page set no favicon, so the browser tab fell back to the browser's default icon instead of the app's branding.
- Add a `<link rel="icon">` to the page generated by `build.js`, pointing at the same `assets/mayara_logo.png` already used as the Signal K `appIcon`. The tab now matches the webapp icon.

Only `build.js` changes — `public/` is gitignored and regenerated at publish time via `prepublishOnly`, so the favicon ships with the published tarball without committing the generated artifact.

## Tested

- `npm run build:all` (lint + build + 106 tests) passes
- Inspected the regenerated `public/index.html` to confirm the `<link rel="icon">` is present and points at `assets/mayara_logo.png`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes
build.js now adds a favicon `<link rel="icon">` to the generated public/index.html redirect page, pointing to assets/mayara_logo.png (the Signal K radar logo). This ensures the browser tab displays the webapp's branding instead of a default icon.

## Testing
- npm run build:all passes with all 106 tests
- Generated public/index.html verified to contain the favicon link

<!-- end of auto-generated comment: release notes by coderabbit.ai -->