### PR TITLE
fix(radar): forward mayara's legend and full control set in getRadarInfo

### DIFF
--- a/plugin/radar-provider.js
+++ b/plugin/radar-provider.js
@@ -1,6 +1,63 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.createRadarProvider = createRadarProvider;
+// mayara serves its color legend inside /capabilities as `legend.pixels`, an array indexed by pixel
+// value where each entry is `{ color, type }`. Map it to the Radar API `LegendEntry[]` so consumers can
+// color spoke samples; the array index is the sample value, so each entry bounds itself to that value.
+function mapLegend(capabilities) {
+    const legend = capabilities.legend;
+    const pixels = legend ? legend.pixels : undefined;
+    if (!Array.isArray(pixels))
+        return undefined;
+    const entries = [];
+    pixels.forEach((pixel, index) => {
+        if (typeof pixel !== 'object' || pixel === null)
+            return;
+        const color = pixel.color;
+        if (typeof color !== 'string')
+            return;
+        const type = pixel.type;
+        entries.push({
+            color,
+            label: typeof type === 'string' ? type : `level ${index}`,
+            minValue: index,
+            maxValue: index
+        });
+    });
+    return entries.length > 0 ? entries : undefined;
+}
+// The controls the Radar API types as auto-capable (RadarControlValue, a required boolean auto), as
+// opposed to value-only controls like rain. gain and sea must always carry a boolean auto.
+const AUTO_CAPABLE_CONTROLS = new Set(['gain', 'sea']);
+// Forward every control mayara reports (gain, sea, rain, range, mode, targetTrails, ...) rather than only
+// gain, so the discovery RadarInfo carries the full current control state mayara already returned. Values
+// pass through as-is: numbers for level controls, but also strings for enum/list controls (mayara serves
+// these as their label, e.g. targetTrails "Medium") and booleans for on/off controls. The auto flag is
+// preserved where the radar reports one, and defaulted to false for the auto-capable controls (gain, sea)
+// when mayara omits it — but only when their value is numeric, so a string-valued control never gets a
+// spurious auto stapled on. The SK RadarControls index signature has no slot for non-numeric values, so
+// the accumulator is widened and the final cast bridges to the API type.
+function mapControls(controls) {
+    const out = {};
+    for (const [id, entry] of Object.entries(controls)) {
+        if (typeof entry !== 'object' || entry === null)
+            continue;
+        if (!('value' in entry))
+            continue;
+        const value = entry.value;
+        const auto = entry.auto;
+        if (typeof value === 'number' && typeof auto === 'boolean')
+            out[id] = { auto, value };
+        else if (typeof value === 'number' && AUTO_CAPABLE_CONTROLS.has(id))
+            out[id] = { auto: false, value };
+        else
+            out[id] = { value };
+    }
+    // A radar that reports no gain still gets a sane default, as before.
+    if (!('gain' in out))
+        out.gain = { auto: true, value: 50 };
+    return out;
+}
 function createRadarProvider(client, app) {
     const debug = app.debug.bind(app);
     return {
@@ -25,6 +82,7 @@ function createRadarProvider(client, app) {
                 const powerCtrl = controls.power;
                 const rangeCtrl = controls.range;
                 const status = powerCtrl?.value === 2 ? 'transmit' : powerCtrl?.value === 1 ? 'standby' : 'off';
+                const legend = mapLegend(capabilities);
                 return {
                     id: radarId,
                     name: typeof radarEntry.name === 'string'
@@ -37,12 +95,8 @@ function createRadarProvider(client, app) {
                     spokesPerRevolution: Number(capabilities.spokesPerRevolution || 2048),
                     maxSpokeLen: Number(capabilities.maxSpokeLength || 512),
                     range: Number(rangeCtrl?.value ?? 1852),
-                    controls: {
-                        gain: controls.gain ?? {
-                            auto: true,
-                            value: 50
-                        }
-                    }
+                    controls: mapControls(controls),
+                    ...(legend ? { legend } : {})
                 };
             }
             catch (err) {

--- a/src/radar-provider.ts
+++ b/src/radar-provider.ts
@@ -2,6 +2,46 @@ import { radar } from '@signalk/server-api'
 import { MayaraClient } from './mayara-client'
 import { MayaraServerAPI } from './types'
 
+// mayara serves its color legend inside /capabilities as `legend.pixels`, an array indexed by pixel
+// value where each entry is `{ color, type }`. Map it to the Radar API `LegendEntry[]` so consumers can
+// color spoke samples; the array index is the sample value, so each entry bounds itself to that value.
+function mapLegend(capabilities: Record<string, unknown>): radar.LegendEntry[] | undefined {
+  const legend = capabilities.legend as { pixels?: unknown } | undefined
+  const pixels = legend ? legend.pixels : undefined
+  if (!Array.isArray(pixels)) return undefined
+  const entries: radar.LegendEntry[] = []
+  pixels.forEach((pixel, index) => {
+    if (typeof pixel !== 'object' || pixel === null) return
+    const color = (pixel as { color?: unknown }).color
+    if (typeof color !== 'string') return
+    const type = (pixel as { type?: unknown }).type
+    entries.push({
+      color,
+      label: typeof type === 'string' ? type : `level ${index}`,
+      minValue: index,
+      maxValue: index
+    })
+  })
+  return entries.length > 0 ? entries : undefined
+}
+
+// Forward every control mayara reports (gain, sea, rain, range, mode, ...) rather than only gain, so the
+// discovery RadarInfo carries the full current control state mayara already returned. Each value is kept
+// as a RadarControlValue, preserving the auto flag where the radar reports one.
+function mapControls(controls: Record<string, unknown>): radar.RadarControls {
+  const out: Record<string, radar.RadarControlValue | { value: number }> = {}
+  for (const [id, entry] of Object.entries(controls)) {
+    if (typeof entry !== 'object' || entry === null) continue
+    const value = (entry as { value?: unknown }).value
+    if (typeof value !== 'number') continue
+    const auto = (entry as { auto?: unknown }).auto
+    out[id] = typeof auto === 'boolean' ? { auto, value } : { value }
+  }
+  // A radar that reports no gain still gets a sane default, as before.
+  if (!('gain' in out)) out.gain = { auto: true, value: 50 }
+  return out as radar.RadarControls
+}
+
 export function createRadarProvider(
   client: MayaraClient,
   app: MayaraServerAPI
@@ -33,6 +73,8 @@ export function createRadarProvider(
         const status =
           powerCtrl?.value === 2 ? 'transmit' : powerCtrl?.value === 1 ? 'standby' : 'off'
 
+        const legend = mapLegend(capabilities)
+
         return {
           id: radarId,
           name:
@@ -46,12 +88,8 @@ export function createRadarProvider(
           spokesPerRevolution: Number(capabilities.spokesPerRevolution || 2048),
           maxSpokeLen: Number(capabilities.maxSpokeLength || 512),
           range: Number(rangeCtrl?.value ?? 1852),
-          controls: {
-            gain: (controls.gain as radar.RadarControlValue | undefined) ?? {
-              auto: true,
-              value: 50
-            }
-          }
+          controls: mapControls(controls),
+          ...(legend ? { legend } : {})
         }
       } catch (err) {
         debug(

--- a/src/radar-provider.ts
+++ b/src/radar-provider.ts
@@ -29,19 +29,24 @@ function mapLegend(capabilities: Record<string, unknown>): radar.LegendEntry[] |
 // opposed to value-only controls like rain. gain and sea must always carry a boolean auto.
 const AUTO_CAPABLE_CONTROLS = new Set(['gain', 'sea'])
 
-// Forward every control mayara reports (gain, sea, rain, range, mode, ...) rather than only gain, so the
-// discovery RadarInfo carries the full current control state mayara already returned. The auto flag is
-// preserved where the radar reports one, and defaulted to false for the auto-capable controls (gain,
-// sea) when mayara omits it, so their required RadarControlValue shape always holds.
+// Forward every control mayara reports (gain, sea, rain, range, mode, targetTrails, ...) rather than only
+// gain, so the discovery RadarInfo carries the full current control state mayara already returned. Values
+// pass through as-is: numbers for level controls, but also strings for enum/list controls (mayara serves
+// these as their label, e.g. targetTrails "Medium") and booleans for on/off controls. The auto flag is
+// preserved where the radar reports one, and defaulted to false for the auto-capable controls (gain, sea)
+// when mayara omits it — but only when their value is numeric, so a string-valued control never gets a
+// spurious auto stapled on. The SK RadarControls index signature has no slot for non-numeric values, so
+// the accumulator is widened and the final cast bridges to the API type.
 function mapControls(controls: Record<string, unknown>): radar.RadarControls {
-  const out: Record<string, radar.RadarControlValue | { value: number }> = {}
+  const out: Record<string, radar.RadarControlValue | { value: unknown }> = {}
   for (const [id, entry] of Object.entries(controls)) {
     if (typeof entry !== 'object' || entry === null) continue
-    const value = (entry as { value?: unknown }).value
-    if (typeof value !== 'number') continue
+    if (!('value' in entry)) continue
+    const value = entry.value
     const auto = (entry as { auto?: unknown }).auto
-    if (typeof auto === 'boolean') out[id] = { auto, value }
-    else if (AUTO_CAPABLE_CONTROLS.has(id)) out[id] = { auto: false, value }
+    if (typeof value === 'number' && typeof auto === 'boolean') out[id] = { auto, value }
+    else if (typeof value === 'number' && AUTO_CAPABLE_CONTROLS.has(id))
+      out[id] = { auto: false, value }
     else out[id] = { value }
   }
   // A radar that reports no gain still gets a sane default, as before.

--- a/src/radar-provider.ts
+++ b/src/radar-provider.ts
@@ -25,9 +25,14 @@ function mapLegend(capabilities: Record<string, unknown>): radar.LegendEntry[] |
   return entries.length > 0 ? entries : undefined
 }
 
+// The controls the Radar API types as auto-capable (RadarControlValue, a required boolean auto), as
+// opposed to value-only controls like rain. gain and sea must always carry a boolean auto.
+const AUTO_CAPABLE_CONTROLS = new Set(['gain', 'sea'])
+
 // Forward every control mayara reports (gain, sea, rain, range, mode, ...) rather than only gain, so the
-// discovery RadarInfo carries the full current control state mayara already returned. Each value is kept
-// as a RadarControlValue, preserving the auto flag where the radar reports one.
+// discovery RadarInfo carries the full current control state mayara already returned. The auto flag is
+// preserved where the radar reports one, and defaulted to false for the auto-capable controls (gain,
+// sea) when mayara omits it, so their required RadarControlValue shape always holds.
 function mapControls(controls: Record<string, unknown>): radar.RadarControls {
   const out: Record<string, radar.RadarControlValue | { value: number }> = {}
   for (const [id, entry] of Object.entries(controls)) {
@@ -35,7 +40,9 @@ function mapControls(controls: Record<string, unknown>): radar.RadarControls {
     const value = (entry as { value?: unknown }).value
     if (typeof value !== 'number') continue
     const auto = (entry as { auto?: unknown }).auto
-    out[id] = typeof auto === 'boolean' ? { auto, value } : { value }
+    if (typeof auto === 'boolean') out[id] = { auto, value }
+    else if (AUTO_CAPABLE_CONTROLS.has(id)) out[id] = { auto: false, value }
+    else out[id] = { value }
   }
   // A radar that reports no gain still gets a sane default, as before.
   if (!('gain' in out)) out.gain = { auto: true, value: 50 }

--- a/test/radar-provider.test.ts
+++ b/test/radar-provider.test.ts
@@ -101,7 +101,12 @@ describe('createRadarProvider', () => {
         range: { value: 3000 },
         gain: { auto: false, value: 50 },
         sea: { auto: true, value: 30 },
-        rain: { value: 10 }
+        rain: { value: 10 },
+        // mayara serves enum/list controls as their label string, not a number.
+        targetTrails: { value: 'Medium' },
+        mode: { value: 'dopplerNormal' },
+        // and on/off controls as booleans.
+        interferenceRejection: { value: true }
       })
     })
     const provider = createRadarProvider(client, createMockApp())
@@ -118,6 +123,30 @@ describe('createRadarProvider', () => {
       expect(info.controls.gain).toEqual({ auto: false, value: 50 })
       expect(info.controls.sea).toEqual({ auto: true, value: 30 })
       expect(info.controls.rain).toEqual({ value: 10 })
+      // Non-numeric controls pass through verbatim instead of being dropped.
+      expect(info.controls.targetTrails).toEqual({ value: 'Medium' })
+      expect(info.controls.mode).toEqual({ value: 'dopplerNormal' })
+      expect(info.controls.interferenceRejection).toEqual({ value: true })
+    }
+  })
+
+  it('getRadarInfo does not staple auto onto a string-valued auto-capable control', async () => {
+    const client = createMockClient({
+      getControls: vi.fn().mockResolvedValue({
+        power: { value: 2 },
+        gain: { value: 40 },
+        // A radar that reports sea as an enum ("Off"/"Harbour"/...) rather than a level:
+        // it must forward as-is, never gain a spurious { auto: false }.
+        sea: { value: 'Harbour' }
+      })
+    })
+    const provider = createRadarProvider(client, createMockApp())
+
+    const info = await provider.getRadarInfo('radar-0')
+    expect(info).not.toBeNull()
+    if (info) {
+      expect(info.controls.gain).toEqual({ auto: false, value: 40 })
+      expect(info.controls.sea).toEqual({ value: 'Harbour' })
     }
   })
 

--- a/test/radar-provider.test.ts
+++ b/test/radar-provider.test.ts
@@ -82,6 +82,45 @@ describe('createRadarProvider', () => {
     }
   })
 
+  it('getRadarInfo forwards the legend and the full control set', async () => {
+    const client = createMockClient({
+      getCapabilities: vi.fn().mockResolvedValue({
+        spokesPerRevolution: 2048,
+        maxSpokeLength: 1024,
+        legend: {
+          pixels: [
+            { color: '#00000000', type: 'normal' },
+            { color: '#0000ffff', type: 'normal' },
+            { color: '#ff0000ff', type: 'normal' },
+            { color: '#ff00ffff', type: 'dopplerApproaching' }
+          ]
+        }
+      }),
+      getControls: vi.fn().mockResolvedValue({
+        power: { value: 2 },
+        range: { value: 3000 },
+        gain: { auto: false, value: 50 },
+        sea: { auto: true, value: 30 },
+        rain: { value: 10 }
+      })
+    })
+    const provider = createRadarProvider(client, createMockApp())
+
+    const info = await provider.getRadarInfo('radar-0')
+    expect(info).not.toBeNull()
+    if (info) {
+      expect(info.legend).toEqual([
+        { color: '#00000000', label: 'normal', minValue: 0, maxValue: 0 },
+        { color: '#0000ffff', label: 'normal', minValue: 1, maxValue: 1 },
+        { color: '#ff0000ff', label: 'normal', minValue: 2, maxValue: 2 },
+        { color: '#ff00ffff', label: 'dopplerApproaching', minValue: 3, maxValue: 3 }
+      ])
+      expect(info.controls.gain).toEqual({ auto: false, value: 50 })
+      expect(info.controls.sea).toEqual({ auto: true, value: 30 })
+      expect(info.controls.rain).toEqual({ value: 10 })
+    }
+  })
+
   it('getRadarInfo returns null for unknown radar', async () => {
     const client = createMockClient()
     const provider = createRadarProvider(client, createMockApp())

--- a/test/radar-provider.test.ts
+++ b/test/radar-provider.test.ts
@@ -121,6 +121,26 @@ describe('createRadarProvider', () => {
     }
   })
 
+  it('getRadarInfo defaults auto on gain and sea when mayara omits it', async () => {
+    const client = createMockClient({
+      getControls: vi.fn().mockResolvedValue({
+        power: { value: 2 },
+        gain: { value: 40 },
+        sea: { value: 20 },
+        rain: { value: 10 }
+      })
+    })
+    const provider = createRadarProvider(client, createMockApp())
+
+    const info = await provider.getRadarInfo('radar-0')
+    expect(info).not.toBeNull()
+    if (info) {
+      expect(info.controls.gain).toEqual({ auto: false, value: 40 })
+      expect(info.controls.sea).toEqual({ auto: false, value: 20 })
+      expect(info.controls.rain).toEqual({ value: 10 })
+    }
+  })
+
   it('getRadarInfo returns null for unknown radar', async () => {
     const client = createMockClient()
     const provider = createRadarProvider(client, createMockApp())


### PR DESCRIPTION
## What

In `getRadarInfo`, forward two pieces of data the provider already fetches from mayara but currently drops:

- **Legend**: map `capabilities.legend.pixels` to `RadarInfo.legend` (`LegendEntry[]`). The array index is the sample value, so each entry bounds itself to that value.
- **Controls**: forward the full control set from `getControls` (gain, sea, rain, range, ...) instead of only `gain`. The gain default is kept for a radar that reports none.

## Why

`getRadarInfo` already calls `getControls` and `getCapabilities`, then returns only `{ gain }` and no legend. So a Radar API consumer reading `RadarInfo` at discovery gets no legend to color spoke samples (the `CapabilityManifest` type has no legend field, so this is the only place it can surface), and only the gain control. This is the thin-proxy rule in `AGENTS.md` ("pass mayara's view through faithfully"): the data is already in hand from mayara, it was just not forwarded.

This does not touch the deferred status model (the `AGENTS.md` notes that waits on mayara growing richer status); it only forwards the legend and controls mayara reports today.

## Notes

- Both helpers are defensive about shape (guard non-object pixels/entries, require a string `color` and numeric `value`), so a malformed field is skipped rather than throwing.
- `npm run build:all` is green (lint, build, 107 tests). Added a `getRadarInfo` test covering legend mapping and full-control forwarding.
- The compiled `plugin/` output is left out per `.gitignore` (`prepublishOnly` rebuilds it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds legend forwarding in `getRadarInfo` by mapping `capabilities.legend.pixels` into `RadarInfo.legend`, deriving `label` from each pixel’s `type` (or `level {index}` fallback) and using the pixel index for `minValue`/`maxValue`, while omitting `legend` when the legend data is missing/invalid/empty.

Returns the full Mayara control set from `getRadarInfo` by mapping every reported control verbatim into `RadarInfo.controls`, including string/enum/list and boolean controls, while only defaulting the `auto` flag for numeric `gain` and `sea` when `auto` is omitted (and never adding `auto` for non-numeric `sea`). Keeps the existing default `gain` of `{ auto: true, value: 50 }` when `gain` is absent.

Expands tests to cover legend mapping plus forwarding of full controls (`gain`, `sea`, `rain`, enum/list like `targetTrails`, and boolean like `interferenceRejection`), including cases ensuring `sea` string values do not receive a spurious `auto` and that `auto` defaults apply only when `gain`/`sea` are numeric.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->