### PR TITLE
fix(versions): authenticate GitHub calls and surface rate-limit failures

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -469,14 +469,14 @@ module.exports = function (app) {
                     };
                     if (ghToken)
                         headers.Authorization = `Bearer ${ghToken}`;
-                    const res = await fetch(url, { headers, signal: AbortSignal.timeout(10000) });
-                    if (res.status === 401 && ghToken) {
+                    const ghRes = await fetch(url, { headers, signal: AbortSignal.timeout(10000) });
+                    if (ghRes.status === 401 && ghToken) {
                         return fetch(url, {
                             headers: { Accept: 'application/vnd.github+json' },
                             signal: AbortSignal.timeout(10000)
                         });
                     }
-                    return res;
+                    return ghRes;
                 };
                 const releasesP = ghFetch(`https://api.github.com/repos/${repo}/releases?per_page=10`);
                 // PR test images (tag `pr<N>`) exist only for OPEN PRs carrying the
@@ -505,9 +505,17 @@ module.exports = function (app) {
                     const r = settled.value;
                     if (r.ok)
                         return 'ok';
-                    if ((r.status === 403 || r.status === 429) &&
-                        r.headers?.get?.('x-ratelimit-remaining') === '0') {
-                        return 'rate-limited';
+                    // Both GitHub rate limits reply 403 or 429. The PRIMARY limit
+                    // sets x-ratelimit-remaining: 0; the SECONDARY (abuse) limit —
+                    // the one a shared WAN IP trips — may instead send Retry-After
+                    // with no remaining:0. Recognize either so the panel reports a
+                    // retryable limit rather than a generic error.
+                    if (r.status === 403 || r.status === 429) {
+                        const remaining = r.headers?.get?.('x-ratelimit-remaining');
+                        const retryAfter = r.headers?.get?.('retry-after');
+                        if (remaining === '0' || (retryAfter !== null && retryAfter !== undefined)) {
+                            return 'rate-limited';
+                        }
                     }
                     return 'error';
                 };

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -449,19 +449,40 @@ module.exports = function (app) {
             // latter belongs in the plugin (it knows which repo to ask). This is the
             // only place mayara still talks to GitHub directly.
             router.get('/api/versions', async (_req, res) => {
-                const headers = { Accept: 'application/vnd.github+json' };
+                // Authenticate the GitHub calls when a token is available. The
+                // unauthenticated limit is 60 req/hr per IP; a boat sharing a WAN
+                // IP exhausts it and the PR test images vanish from the dropdown.
+                // A token lifts the cap to 5000/hr. Optional — absent, the calls
+                // stay unauthenticated (no regression). Both fetches share this
+                // one object, so a single conditional authenticates both.
+                const ghToken = (0, signalk_token_1.readGithubToken)(app.getDataDirPath());
                 const repo = 'MarineYachtRadar/mayara-server';
-                const releasesP = fetch(`https://api.github.com/repos/${repo}/releases?per_page=10`, {
-                    headers,
-                    signal: AbortSignal.timeout(10000)
-                });
+                // Fetch a GitHub path, authenticated when a token is available. A
+                // token lifts the rate limit from 60 to 5000 req/hr per IP, curing
+                // the shared-WAN-IP exhaustion that hides the PR test images. If a
+                // present token is rejected (401), retry once WITHOUT it: a bad or
+                // expired token must never be worse than no token — the same
+                // unauthenticated call would have succeeded.
+                const ghFetch = async (url) => {
+                    const headers = {
+                        Accept: 'application/vnd.github+json'
+                    };
+                    if (ghToken)
+                        headers.Authorization = `Bearer ${ghToken}`;
+                    const res = await fetch(url, { headers, signal: AbortSignal.timeout(10000) });
+                    if (res.status === 401 && ghToken) {
+                        return fetch(url, {
+                            headers: { Accept: 'application/vnd.github+json' },
+                            signal: AbortSignal.timeout(10000)
+                        });
+                    }
+                    return res;
+                };
+                const releasesP = ghFetch(`https://api.github.com/repos/${repo}/releases?per_page=10`);
                 // PR test images (tag `pr<N>`) exist only for OPEN PRs carrying the
                 // `build-image` label; the server-side cleanup job deletes the image
                 // when the PR closes. So list open PRs and keep the labeled ones.
-                const pullsP = fetch(`https://api.github.com/repos/${repo}/pulls?state=open&per_page=30`, {
-                    headers,
-                    signal: AbortSignal.timeout(10000)
-                });
+                const pullsP = ghFetch(`https://api.github.com/repos/${repo}/pulls?state=open&per_page=30`);
                 const [relSettled, pullSettled] = await Promise.allSettled([releasesP, pullsP]);
                 const releases = [];
                 if (relSettled.status === 'fulfilled' && relSettled.value.ok) {
@@ -478,15 +499,30 @@ module.exports = function (app) {
                         .map((p) => ({ tag: `pr${p.number}`, pr: p.number, title: p.title }))
                         .filter((p) => SAFE_TAG.test(p.tag)));
                 }
-                // Both sources down → 502 so the panel keeps its prior dropdown
-                // (it ignores non-ok responses). One source down → degrade silently.
-                const relFailed = relSettled.status === 'rejected' || !relSettled.value.ok;
-                const pullFailed = pullSettled.status === 'rejected' || !pullSettled.value.ok;
-                if (relFailed && pullFailed) {
-                    res.status(502).json({ error: 'Failed to fetch versions' });
+                const classify = (settled) => {
+                    if (settled.status !== 'fulfilled')
+                        return 'error';
+                    const r = settled.value;
+                    if (r.ok)
+                        return 'ok';
+                    if ((r.status === 403 || r.status === 429) &&
+                        r.headers?.get?.('x-ratelimit-remaining') === '0') {
+                        return 'rate-limited';
+                    }
+                    return 'error';
+                };
+                const relStatus = classify(relSettled);
+                const pullStatus = classify(pullSettled);
+                const sources = { releases: relStatus, prImages: pullStatus };
+                // 502 only when BOTH sources failed — the panel then keeps its
+                // prior dropdown. Partial success is still success: return
+                // whatever loaded plus the per-source status so the panel can say
+                // which source (and why) is missing.
+                if (relStatus !== 'ok' && pullStatus !== 'ok') {
+                    res.status(502).json({ error: 'Failed to fetch versions', sources });
                     return;
                 }
-                res.json([...releases, ...prImages]);
+                res.json({ versions: [...releases, ...prImages], sources });
             });
         }
     };
@@ -856,7 +892,13 @@ module.exports = function (app) {
                 // Function, not value: picks up live edits to the version
                 // setting without requiring a re-register.
                 currentTag: () => currentSettings?.mayaraVersion ?? 'latest',
-                versionSource: containers.updates.sources.githubReleases('MarineYachtRadar/mayara-server')
+                // Authenticate the update check's GitHub calls when a token is
+                // available — same optional token as /api/versions. Without it,
+                // the unauthenticated 60/hr limit (or GitHub's stickier 429
+                // secondary limit on a shared WAN IP) makes "Check" fail.
+                versionSource: containers.updates.sources.githubReleases('MarineYachtRadar/mayara-server', {
+                    token: (0, signalk_token_1.readGithubToken)(app.getDataDirPath())
+                })
             });
             app.debug('Registered with signalk-container update service');
         }

--- a/src/configpanel/PluginConfigurationPanel.js
+++ b/src/configpanel/PluginConfigurationPanel.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from "react";
-import { deriveVersionsView, runningTagFallback } from "./versionsView";
+import { deriveVersionsView, runningTagFallback, splitVersions } from "./versionsView";
 
 const S = {
   root: {
@@ -384,12 +384,10 @@ export default function PluginConfigurationPanel({ configuration, save }) {
     ? false  // PR test images and floating "latest" aren't version-compared
     : versions.length > 0 && !versions.some((v) => v.tag === mayaraVersion);
 
-  // PR test images carry a `pr` number (no `prerelease`); split them out so
-  // they aren't misclassified as stable releases.
-  const prVersions = versions.filter((v) => typeof v.pr === "number");
-  const releaseVersions = versions.filter((v) => typeof v.pr !== "number");
-  const stableVersions = releaseVersions.filter((v) => !v.prerelease).slice(0, 5);
-  const preVersions = releaseVersions.filter((v) => v.prerelease).slice(0, 3);
+  // The rendered option buckets. splitVersions is the shared source of the
+  // slice limits, so shownTags/runningTagFallback can never disagree with
+  // what these <optgroup>s actually render.
+  const { prVersions, stableVersions, preVersions } = splitVersions(versions);
 
   // When the running image's tag isn't among the rendered options — e.g. a
   // pr<N> whose /pulls fetch was rate-limited, or a stable pin that fell out

--- a/src/configpanel/PluginConfigurationPanel.js
+++ b/src/configpanel/PluginConfigurationPanel.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from "react";
+import { deriveVersionsView, runningTagFallback } from "./versionsView";
 
 const S = {
   root: {
@@ -243,6 +244,7 @@ export default function PluginConfigurationPanel({ configuration, save }) {
 
   const [versions, setVersions] = useState([]);
   const [versionsLoading, setVersionsLoading] = useState(false);
+  const [versionsError, setVersionsError] = useState("");
   const [pluginStatus, setPluginStatus] = useState(null);
   const [statusLoading, setStatusLoading] = useState(true);
   const [actionStatus, setActionStatus] = useState("");
@@ -254,8 +256,17 @@ export default function PluginConfigurationPanel({ configuration, save }) {
     setVersionsLoading(true);
     try {
       const res = await fetch("/plugins/mayara-server-signalk-plugin/api/versions");
-      if (res.ok) setVersions(await res.json());
-    } catch { /* offline */ }
+      const body = res.ok ? await res.json() : null;
+      // deriveVersionsView (unit-tested in test/versionsView.test.ts)
+      // decides the list + error line from the response; a null list on a
+      // 502 means "keep the prior dropdown rather than wipe it".
+      const view = deriveVersionsView(res.ok, body);
+      if (view.versions !== null) setVersions(view.versions);
+      setVersionsError(view.versionsError);
+    } catch {
+      // Offline: preserve whatever is already shown.
+      setVersionsError("⚠ Offline — showing last known versions");
+    }
     setVersionsLoading(false);
   }, []);
 
@@ -380,6 +391,13 @@ export default function PluginConfigurationPanel({ configuration, save }) {
   const stableVersions = releaseVersions.filter((v) => !v.prerelease).slice(0, 5);
   const preVersions = releaseVersions.filter((v) => v.prerelease).slice(0, 3);
 
+  // When the running image's tag isn't among the rendered options — e.g. a
+  // pr<N> whose /pulls fetch was rate-limited, or a stable pin that fell out
+  // of the top-N — inject a synthetic option so the controlled <select>
+  // never renders blank and silently resets the operator's real running
+  // image. runningTagFallback is unit-tested in test/versionsView.test.ts.
+  const runningFallbackTag = runningTagFallback(mayaraVersion, versions);
+
   return (
     <div style={S.root}>
       {/* Status */}
@@ -466,6 +484,9 @@ export default function PluginConfigurationPanel({ configuration, save }) {
                   ))}
                 </optgroup>
               )}
+              {runningFallbackTag && (
+                <option value={runningFallbackTag}>{runningFallbackTag} (running)</option>
+              )}
             </select>
             {versionsLoading && <span style={S.hint}>loading...</span>}
             <button
@@ -492,6 +513,13 @@ export default function PluginConfigurationPanel({ configuration, save }) {
               </>
             )}
           </div>
+
+          {versionsError && (
+            <div style={S.fieldRow}>
+              <span style={S.label} />
+              <span style={{ ...S.hint, color: "#ef4444" }}>{versionsError}</span>
+            </div>
+          )}
 
           <CollapsibleSection title="Advanced">
             <div style={S.fieldRow}>

--- a/src/configpanel/versionsView.d.ts
+++ b/src/configpanel/versionsView.d.ts
@@ -1,0 +1,27 @@
+// Type declarations for the plain-JS version-view helpers so the
+// TypeScript unit tests (and any TS consumer) get real types. The
+// implementation stays .js because the webpack config panel build uses
+// babel-loader and only resolves .js/.jsx.
+
+export interface VersionEntry {
+  tag: string
+  prerelease?: boolean
+  pr?: number
+  title?: string
+}
+
+export interface VersionsView {
+  /** The list to show, or null to signal "keep the caller's prior list". */
+  versions: VersionEntry[] | null
+  /** Operator-facing error line, '' when there is nothing to report. */
+  versionsError: string
+}
+
+export function deriveVersionsView(ok: boolean, body: unknown): VersionsView
+
+export function shownTags(versions: VersionEntry[]): Set<string>
+
+export function runningTagFallback(
+  mayaraVersion: string | undefined | null,
+  versions: VersionEntry[]
+): string | null

--- a/src/configpanel/versionsView.d.ts
+++ b/src/configpanel/versionsView.d.ts
@@ -19,6 +19,12 @@ export interface VersionsView {
 
 export function deriveVersionsView(ok: boolean, body: unknown): VersionsView
 
+export function splitVersions(versions: VersionEntry[]): {
+  prVersions: VersionEntry[]
+  stableVersions: VersionEntry[]
+  preVersions: VersionEntry[]
+}
+
 export function shownTags(versions: VersionEntry[]): Set<string>
 
 export function runningTagFallback(

--- a/src/configpanel/versionsView.js
+++ b/src/configpanel/versionsView.js
@@ -1,0 +1,75 @@
+// Pure view-logic for the version dropdown, extracted from
+// PluginConfigurationPanel.js so it can be unit-tested without a DOM.
+// These functions decide what the panel shows from the /api/versions
+// response; the component only wires them to state and JSX.
+
+/**
+ * Derive the versions list and the operator-facing error line from an
+ * /api/versions response.
+ *
+ * @param {boolean} ok - res.ok
+ * @param {*} body - parsed JSON body (the new {versions, sources} shape,
+ *   or a legacy bare array for back-compat during a version skew)
+ * @returns {{ versions: Array, versionsError: string }}
+ */
+export function deriveVersionsView(ok, body) {
+  if (!ok) {
+    // Both sources failed (502): the caller keeps its prior list; tell the
+    // operator why rather than implying the dropdown is authoritative.
+    return {
+      versions: null, // null => caller preserves its existing list
+      versionsError:
+        "⚠ Could not reach GitHub — showing last known versions, retry",
+    };
+  }
+  // Guard against a malformed 200 payload (null / non-object / no fields)
+  // so reading .versions/.sources can't throw before the fallbacks apply.
+  const obj = body && typeof body === "object" ? body : {};
+  const list = Array.isArray(obj) ? obj : Array.isArray(obj.versions) ? obj.versions : [];
+  const sources =
+    !Array.isArray(obj) && obj.sources && typeof obj.sources === "object"
+      ? obj.sources
+      : {};
+  let versionsError = "";
+  if (sources.prImages === "rate-limited") {
+    // The PR-images source specifically failed — name it, since a running
+    // pr<N> vanishing from the list is the visible symptom operators hit.
+    versionsError =
+      "⚠ GitHub rate-limited — PR test images temporarily unavailable, retry shortly";
+  } else if (sources.releases === "rate-limited") {
+    versionsError =
+      "⚠ GitHub rate-limited — some versions temporarily unavailable, retry shortly";
+  } else if (sources.prImages === "error" || sources.releases === "error") {
+    versionsError = "⚠ Could not fetch some versions from GitHub, retry";
+  }
+  return { versions: list, versionsError };
+}
+
+/**
+ * The set of tags the dropdown renders as real options. Used to decide
+ * whether the running tag needs a synthetic fallback option.
+ */
+export function shownTags(versions) {
+  const prVersions = versions.filter((v) => typeof v.pr === "number");
+  const releaseVersions = versions.filter((v) => typeof v.pr !== "number");
+  const stableVersions = releaseVersions.filter((v) => !v.prerelease).slice(0, 5);
+  const preVersions = releaseVersions.filter((v) => v.prerelease).slice(0, 3);
+  return new Set([
+    "latest",
+    "main",
+    ...preVersions.map((v) => v.tag),
+    ...stableVersions.map((v) => v.tag),
+    ...prVersions.map((v) => v.tag),
+  ]);
+}
+
+/**
+ * The running image's tag if it is NOT among the rendered options (so the
+ * controlled <select> would otherwise render blank and silently reset the
+ * operator's real running image), else null. Covers a pr<N> whose /pulls
+ * fetch was rate-limited and a stable pin that fell out of the top-N.
+ */
+export function runningTagFallback(mayaraVersion, versions) {
+  if (!mayaraVersion) return null;
+  return shownTags(versions).has(mayaraVersion) ? null : mayaraVersion;
+}

--- a/src/configpanel/versionsView.js
+++ b/src/configpanel/versionsView.js
@@ -46,14 +46,26 @@ export function deriveVersionsView(ok, body) {
 }
 
 /**
- * The set of tags the dropdown renders as real options. Used to decide
- * whether the running tag needs a synthetic fallback option.
+ * Split the version list into the buckets the dropdown renders: PR test
+ * images, the top 5 stable releases, and the top 3 pre-releases. The
+ * single source of the slice limits — the panel's <optgroup> builder AND
+ * shownTags both consume this, so the running-tag fallback can never
+ * disagree with what is actually shown.
  */
-export function shownTags(versions) {
+export function splitVersions(versions) {
   const prVersions = versions.filter((v) => typeof v.pr === "number");
   const releaseVersions = versions.filter((v) => typeof v.pr !== "number");
   const stableVersions = releaseVersions.filter((v) => !v.prerelease).slice(0, 5);
   const preVersions = releaseVersions.filter((v) => v.prerelease).slice(0, 3);
+  return { prVersions, stableVersions, preVersions };
+}
+
+/**
+ * The set of tags the dropdown renders as real options. Used to decide
+ * whether the running tag needs a synthetic fallback option.
+ */
+export function shownTags(versions) {
+  const { prVersions, stableVersions, preVersions } = splitVersions(versions);
   return new Set([
     "latest",
     "main",

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import {
   beginTokenRequest,
   deleteCachedToken,
   readCachedToken,
+  readGithubToken,
   validateCachedToken,
   writeCachedToken
 } from './signalk-token'
@@ -498,20 +499,41 @@ module.exports = function (app: MayaraServerAPI): Plugin {
       // latter belongs in the plugin (it knows which repo to ask). This is the
       // only place mayara still talks to GitHub directly.
       router.get('/api/versions', async (_req: Request, res: Response) => {
-        const headers = { Accept: 'application/vnd.github+json' }
+        // Authenticate the GitHub calls when a token is available. The
+        // unauthenticated limit is 60 req/hr per IP; a boat sharing a WAN
+        // IP exhausts it and the PR test images vanish from the dropdown.
+        // A token lifts the cap to 5000/hr. Optional — absent, the calls
+        // stay unauthenticated (no regression). Both fetches share this
+        // one object, so a single conditional authenticates both.
+        const ghToken = readGithubToken(app.getDataDirPath())
         const repo = 'MarineYachtRadar/mayara-server'
 
-        const releasesP = fetch(`https://api.github.com/repos/${repo}/releases?per_page=10`, {
-          headers,
-          signal: AbortSignal.timeout(10000)
-        })
+        // Fetch a GitHub path, authenticated when a token is available. A
+        // token lifts the rate limit from 60 to 5000 req/hr per IP, curing
+        // the shared-WAN-IP exhaustion that hides the PR test images. If a
+        // present token is rejected (401), retry once WITHOUT it: a bad or
+        // expired token must never be worse than no token — the same
+        // unauthenticated call would have succeeded.
+        const ghFetch = async (url: string): Promise<globalThis.Response> => {
+          const headers: Record<string, string> = {
+            Accept: 'application/vnd.github+json'
+          }
+          if (ghToken) headers.Authorization = `Bearer ${ghToken}`
+          const res = await fetch(url, { headers, signal: AbortSignal.timeout(10000) })
+          if (res.status === 401 && ghToken) {
+            return fetch(url, {
+              headers: { Accept: 'application/vnd.github+json' },
+              signal: AbortSignal.timeout(10000)
+            })
+          }
+          return res
+        }
+
+        const releasesP = ghFetch(`https://api.github.com/repos/${repo}/releases?per_page=10`)
         // PR test images (tag `pr<N>`) exist only for OPEN PRs carrying the
         // `build-image` label; the server-side cleanup job deletes the image
         // when the PR closes. So list open PRs and keep the labeled ones.
-        const pullsP = fetch(`https://api.github.com/repos/${repo}/pulls?state=open&per_page=30`, {
-          headers,
-          signal: AbortSignal.timeout(10000)
-        })
+        const pullsP = ghFetch(`https://api.github.com/repos/${repo}/pulls?state=open&per_page=30`)
 
         const [relSettled, pullSettled] = await Promise.allSettled([releasesP, pullsP])
 
@@ -544,16 +566,48 @@ module.exports = function (app: MayaraServerAPI): Plugin {
           )
         }
 
-        // Both sources down → 502 so the panel keeps its prior dropdown
-        // (it ignores non-ok responses). One source down → degrade silently.
-        const relFailed = relSettled.status === 'rejected' || !relSettled.value.ok
-        const pullFailed = pullSettled.status === 'rejected' || !pullSettled.value.ok
-        if (relFailed && pullFailed) {
-          res.status(502).json({ error: 'Failed to fetch versions' })
+        // Classify each source so a rate-limited/failed one is RECORDED
+        // rather than silently dropped: releases-ok + pulls-rate-limited
+        // used to return the release list with the PR images gone and no
+        // signal, so the panel could not tell "no PR images exist" from
+        // "couldn't fetch them". Read the rate-limit response headers
+        // (previously discarded) to distinguish throttling from a generic
+        // error. Typed against a minimal structural shape (headers may be
+        // absent) so the optional access is legitimate, not just a cast of
+        // the DOM Response — a header-less response never throws.
+        type ClassifiableResponse = {
+          ok: boolean
+          status: number
+          headers?: { get?: (name: string) => string | null }
+        }
+        const classify = (
+          settled: PromiseSettledResult<ClassifiableResponse>
+        ): 'ok' | 'rate-limited' | 'error' => {
+          if (settled.status !== 'fulfilled') return 'error'
+          const r = settled.value
+          if (r.ok) return 'ok'
+          if (
+            (r.status === 403 || r.status === 429) &&
+            r.headers?.get?.('x-ratelimit-remaining') === '0'
+          ) {
+            return 'rate-limited'
+          }
+          return 'error'
+        }
+        const relStatus = classify(relSettled)
+        const pullStatus = classify(pullSettled)
+        const sources = { releases: relStatus, prImages: pullStatus }
+
+        // 502 only when BOTH sources failed — the panel then keeps its
+        // prior dropdown. Partial success is still success: return
+        // whatever loaded plus the per-source status so the panel can say
+        // which source (and why) is missing.
+        if (relStatus !== 'ok' && pullStatus !== 'ok') {
+          res.status(502).json({ error: 'Failed to fetch versions', sources })
           return
         }
 
-        res.json([...releases, ...prImages])
+        res.json({ versions: [...releases, ...prImages], sources })
       })
     }
   }
@@ -1001,7 +1055,13 @@ module.exports = function (app: MayaraServerAPI): Plugin {
         // Function, not value: picks up live edits to the version
         // setting without requiring a re-register.
         currentTag: () => currentSettings?.mayaraVersion ?? 'latest',
-        versionSource: containers.updates.sources.githubReleases('MarineYachtRadar/mayara-server')
+        // Authenticate the update check's GitHub calls when a token is
+        // available — same optional token as /api/versions. Without it,
+        // the unauthenticated 60/hr limit (or GitHub's stickier 429
+        // secondary limit on a shared WAN IP) makes "Check" fail.
+        versionSource: containers.updates.sources.githubReleases('MarineYachtRadar/mayara-server', {
+          token: readGithubToken(app.getDataDirPath())
+        })
       })
       app.debug('Registered with signalk-container update service')
     } catch (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -519,14 +519,14 @@ module.exports = function (app: MayaraServerAPI): Plugin {
             Accept: 'application/vnd.github+json'
           }
           if (ghToken) headers.Authorization = `Bearer ${ghToken}`
-          const res = await fetch(url, { headers, signal: AbortSignal.timeout(10000) })
-          if (res.status === 401 && ghToken) {
+          const ghRes = await fetch(url, { headers, signal: AbortSignal.timeout(10000) })
+          if (ghRes.status === 401 && ghToken) {
             return fetch(url, {
               headers: { Accept: 'application/vnd.github+json' },
               signal: AbortSignal.timeout(10000)
             })
           }
-          return res
+          return ghRes
         }
 
         const releasesP = ghFetch(`https://api.github.com/repos/${repo}/releases?per_page=10`)
@@ -586,11 +586,17 @@ module.exports = function (app: MayaraServerAPI): Plugin {
           if (settled.status !== 'fulfilled') return 'error'
           const r = settled.value
           if (r.ok) return 'ok'
-          if (
-            (r.status === 403 || r.status === 429) &&
-            r.headers?.get?.('x-ratelimit-remaining') === '0'
-          ) {
-            return 'rate-limited'
+          // Both GitHub rate limits reply 403 or 429. The PRIMARY limit
+          // sets x-ratelimit-remaining: 0; the SECONDARY (abuse) limit —
+          // the one a shared WAN IP trips — may instead send Retry-After
+          // with no remaining:0. Recognize either so the panel reports a
+          // retryable limit rather than a generic error.
+          if (r.status === 403 || r.status === 429) {
+            const remaining = r.headers?.get?.('x-ratelimit-remaining')
+            const retryAfter = r.headers?.get?.('retry-after')
+            if (remaining === '0' || (retryAfter !== null && retryAfter !== undefined)) {
+              return 'rate-limited'
+            }
           }
           return 'error'
         }

--- a/src/signalk-token.ts
+++ b/src/signalk-token.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { request as httpsRequest } from 'https'
 
 const TOKEN_FILENAME = 'signalk-token'
+const GITHUB_TOKEN_FILENAME = 'github-token'
 const POLL_INTERVAL_MS = 5_000
 
 /** Minimal response shape both transports below resolve to. */
@@ -114,6 +115,35 @@ export interface EnsureOptions {
  */
 export function readCachedToken(dataDir: string): string | undefined {
   const path = join(dataDir, TOKEN_FILENAME)
+  if (!existsSync(path)) return undefined
+  const raw = readFileSync(path, 'utf8').trim()
+  return raw.length > 0 ? raw : undefined
+}
+
+/**
+ * Read an OPTIONAL GitHub token for the version-list endpoint's REST
+ * calls. Unauthenticated GitHub REST is capped at 60 requests/hour per
+ * IP; a boat sharing a WAN IP with other GitHub-polling plugins can
+ * exhaust that, which hides the PR test images from the version dropdown.
+ * A token raises the cap to 5000/hour and cures the exhaustion.
+ *
+ * The token is optional — absent, the calls stay unauthenticated (no
+ * regression) — and is NOT a user-facing config field. Sources, first
+ * hit wins: `GITHUB_TOKEN`, then `GH_TOKEN`, then a host-only
+ * `${dataDir}/github-token` file (same private per-instance dir as the
+ * Signal K token). It is read plugin-side only (Node in the SK process)
+ * and never handed to the container, so the container-UID readability
+ * concern that forces the SK token through an env var does not apply — a
+ * host 0600 file is fine. A fine-grained PAT with public-repo read is
+ * enough since the repo is public; even a zero-scope token lifts the cap.
+ */
+export function readGithubToken(dataDir: string): string | undefined {
+  // Trim each source independently so a whitespace-only GITHUB_TOKEN does
+  // not short-circuit the `||` before GH_TOKEN is consulted (which would
+  // silently revert to unauthenticated despite a valid GH_TOKEN).
+  const env = (process.env.GITHUB_TOKEN ?? '').trim() || (process.env.GH_TOKEN ?? '').trim()
+  if (env.length > 0) return env
+  const path = join(dataDir, GITHUB_TOKEN_FILENAME)
   if (!existsSync(path)) return undefined
   const raw = readFileSync(path, 'utf8').trim()
   return raw.length > 0 ? raw : undefined

--- a/src/types.ts
+++ b/src/types.ts
@@ -139,7 +139,14 @@ export interface UpdateServiceApi {
   sources: {
     githubReleases: (
       repo: string,
-      options?: { allowPrerelease?: boolean; tagPrefix?: string }
+      options?: {
+        allowPrerelease?: boolean
+        tagPrefix?: string
+        // Optional GitHub token (Authorization: Bearer) — lifts the REST
+        // rate limit from 60 to 5000 req/hr per IP, so the update check
+        // doesn't 403/429 on a boat sharing a WAN IP.
+        token?: string
+      }
     ) => VersionSource
     dockerHubTags: (image: string, options?: { filter?: (tag: string) => boolean }) => VersionSource
   }

--- a/test/container-integration.test.ts
+++ b/test/container-integration.test.ts
@@ -823,6 +823,18 @@ describe('mayara-server-signalk-plugin container integration', () => {
         json: () => Promise.resolve([])
       })
 
+    // GitHub's SECONDARY (abuse) limit — the one a shared WAN IP trips:
+    // 429 with Retry-After but NO x-ratelimit-remaining: 0.
+    const secondaryRateLimited = () =>
+      Promise.resolve({
+        ok: false,
+        status: 429,
+        headers: {
+          get: (h: string) => (h === 'retry-after' ? '60' : null)
+        },
+        json: () => Promise.resolve([])
+      })
+
     it('merges release tags and labeled open PRs, skipping unlabeled PRs', async () => {
       stubFetch((url) => {
         if (url.includes('/releases')) {
@@ -1014,6 +1026,27 @@ describe('mayara-server-signalk-plugin container integration', () => {
 
       const body = res.body as { sources: { releases: string; prImages: string } }
       expect(body.sources).toEqual({ releases: 'ok', prImages: 'error' })
+      await plugin.stop()
+    })
+
+    it('classifies a secondary-limit 429 (Retry-After, no remaining:0) as rate-limited', async () => {
+      // The abuse limit a shared WAN IP trips: 429 with Retry-After but
+      // no x-ratelimit-remaining: 0. Must be reported as rate-limited so
+      // the panel says "retry shortly", not a generic error.
+      stubFetch((url) => {
+        if (url.includes('/releases')) {
+          return okJson([{ tag_name: 'v3.4.0', prerelease: false, draft: false }])
+        }
+        return secondaryRateLimited()
+      })
+
+      const { router, plugin } = await loadPlugin()
+      const handler = getHandler(router, 'GET /api/versions')
+      const res = makeRes()
+      await handler({}, res)
+
+      const body = res.body as { sources: { releases: string; prImages: string } }
+      expect(body.sources).toEqual({ releases: 'ok', prImages: 'rate-limited' })
       await plugin.stop()
     })
   })

--- a/test/container-integration.test.ts
+++ b/test/container-integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { readFileSync } from 'fs'
+import { readFileSync, rmSync } from 'fs'
 import { join } from 'path'
 import type {
   ContainerConfig,
@@ -530,10 +530,46 @@ describe('mayara-server-signalk-plugin container integration', () => {
 
     it('uses githubReleases source pointing at MarineYachtRadar/mayara-server', async () => {
       const { containers, plugin } = await loadPlugin()
-      expect(containers.updates.sources.githubReleases).toHaveBeenCalledWith(
-        'MarineYachtRadar/mayara-server'
-      )
+      const call = vi.mocked(containers.updates.sources.githubReleases).mock.calls[0]
+      expect(call[0]).toBe('MarineYachtRadar/mayara-server')
+      // Second arg is the options object carrying the (optional) token.
+      expect(call[1]).toHaveProperty('token')
       await plugin.stop()
+    })
+
+    it('passes the GitHub token into the update source when one is available', async () => {
+      const saved = process.env.GITHUB_TOKEN
+      process.env.GITHUB_TOKEN = 'ghp_update_test'
+      try {
+        const { containers, plugin } = await loadPlugin()
+        expect(containers.updates.sources.githubReleases).toHaveBeenCalledWith(
+          'MarineYachtRadar/mayara-server',
+          { token: 'ghp_update_test' }
+        )
+        await plugin.stop()
+      } finally {
+        if (saved === undefined) delete process.env.GITHUB_TOKEN
+        else process.env.GITHUB_TOKEN = saved
+      }
+    })
+
+    it('passes token undefined (unauthenticated, no regression) when none is available', async () => {
+      const savedGithub = process.env.GITHUB_TOKEN
+      const savedGh = process.env.GH_TOKEN
+      delete process.env.GITHUB_TOKEN
+      delete process.env.GH_TOKEN
+      rmSync(join('/tmp/mayara-test', 'github-token'), { force: true })
+      try {
+        const { containers, plugin } = await loadPlugin()
+        expect(containers.updates.sources.githubReleases).toHaveBeenCalledWith(
+          'MarineYachtRadar/mayara-server',
+          { token: undefined }
+        )
+        await plugin.stop()
+      } finally {
+        if (savedGithub !== undefined) process.env.GITHUB_TOKEN = savedGithub
+        if (savedGh !== undefined) process.env.GH_TOKEN = savedGh
+      }
     })
 
     it('currentTag is a function that reads live config', async () => {
@@ -728,19 +764,64 @@ describe('mayara-server-signalk-plugin container integration', () => {
   describe('GET /api/versions', () => {
     // The route does a real `fetch` against GitHub; stub it with a
     // URL-discriminating implementation so each test controls both sources.
+    // CI (GitHub Actions) injects GITHUB_TOKEN into the environment, which
+    // readGithubToken would pick up — delete both here so the auth/no-auth
+    // cases are deterministic, and restore whatever CI set afterwards.
+    let savedGithubToken: string | undefined
+    let savedGhToken: string | undefined
+    beforeEach(() => {
+      savedGithubToken = process.env.GITHUB_TOKEN
+      savedGhToken = process.env.GH_TOKEN
+      delete process.env.GITHUB_TOKEN
+      delete process.env.GH_TOKEN
+      // makeMockApp hardcodes getDataDirPath() => '/tmp/mayara-test' (a
+      // shared path, not an isolated temp dir). readGithubToken falls back
+      // to a github-token FILE there, so remove any stray one to keep the
+      // no-token / auth-header cases hermetic regardless of ambient state.
+      rmSync(join('/tmp/mayara-test', 'github-token'), { force: true })
+    })
     afterEach(() => {
       vi.unstubAllGlobals()
+      if (savedGithubToken === undefined) delete process.env.GITHUB_TOKEN
+      else process.env.GITHUB_TOKEN = savedGithubToken
+      if (savedGhToken === undefined) delete process.env.GH_TOKEN
+      else process.env.GH_TOKEN = savedGhToken
     })
 
-    function stubFetch(impl: (url: string) => Promise<unknown>) {
+    // Captured (url, init) tuples so tests can assert request headers.
+    let fetchCalls: { url: string; init?: { headers?: Record<string, string> } }[]
+
+    function stubFetch(impl: (url: string, init?: unknown) => Promise<unknown>) {
+      fetchCalls = []
       vi.stubGlobal(
         'fetch',
-        vi.fn((url: string) => impl(url))
+        vi.fn((url: string, init?: { headers?: Record<string, string> }) => {
+          fetchCalls.push({ url, init })
+          return impl(url, init)
+        })
       )
     }
 
+    // Responses carry a headers.get() so the classify() rate-limit check
+    // (headers.get('x-ratelimit-remaining')) never throws on a stub.
     const okJson = (body: unknown) =>
-      Promise.resolve({ ok: true, json: () => Promise.resolve(body) })
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        json: () => Promise.resolve(body)
+      })
+
+    // GitHub's primary-rate-limit signature: 403 with remaining == '0'.
+    const rateLimited = (status = 403) =>
+      Promise.resolve({
+        ok: false,
+        status,
+        headers: {
+          get: (h: string) => (h === 'x-ratelimit-remaining' ? '0' : null)
+        },
+        json: () => Promise.resolve([])
+      })
 
     it('merges release tags and labeled open PRs, skipping unlabeled PRs', async () => {
       stubFetch((url) => {
@@ -766,18 +847,48 @@ describe('mayara-server-signalk-plugin container integration', () => {
       await handler({}, res)
 
       expect(res.statusCode).toBe(200)
-      const body = res.body as { tag: string; prerelease?: boolean; pr?: number; title?: string }[]
-      expect(body).toContainEqual({ tag: 'v3.4.0', prerelease: false })
-      expect(body).toContainEqual({ tag: 'v3.5.0-rc1', prerelease: true })
-      expect(body).toContainEqual({ tag: 'pr123', pr: 123, title: 'Fix gain' })
+      const body = res.body as {
+        versions: { tag: string; prerelease?: boolean; pr?: number; title?: string }[]
+        sources: { releases: string; prImages: string }
+      }
+      expect(body.versions).toContainEqual({ tag: 'v3.4.0', prerelease: false })
+      expect(body.versions).toContainEqual({ tag: 'v3.5.0-rc1', prerelease: true })
+      expect(body.versions).toContainEqual({ tag: 'pr123', pr: 123, title: 'Fix gain' })
       // draft release filtered out
-      expect(body.some((v) => v.tag === 'v3.3.0-draft')).toBe(false)
+      expect(body.versions.some((v) => v.tag === 'v3.3.0-draft')).toBe(false)
       // unlabeled PR filtered out
-      expect(body.some((v) => v.tag === 'pr99')).toBe(false)
+      expect(body.versions.some((v) => v.tag === 'pr99')).toBe(false)
+      expect(body.sources).toEqual({ releases: 'ok', prImages: 'ok' })
       await plugin.stop()
     })
 
-    it('still returns releases when the PRs request fails (degrade, not fail)', async () => {
+    it('records prImages as rate-limited when /pulls is throttled but keeps releases (the boat bug)', async () => {
+      stubFetch((url) => {
+        if (url.includes('/releases')) {
+          return okJson([{ tag_name: 'v3.4.0', prerelease: false, draft: false }])
+        }
+        return rateLimited()
+      })
+
+      const { router, plugin } = await loadPlugin()
+      const handler = getHandler(router, 'GET /api/versions')
+      const res = makeRes()
+      await handler({}, res)
+
+      expect(res.statusCode).toBe(200)
+      const body = res.body as {
+        versions: { tag: string }[]
+        sources: { releases: string; prImages: string }
+      }
+      expect(body.versions).toContainEqual({ tag: 'v3.4.0', prerelease: false })
+      expect(body.versions.some((v) => v.tag.startsWith('pr'))).toBe(false)
+      // The failure is RECORDED, not silently dropped, so the panel can
+      // say "rate-limited, retry" instead of implying no PR images exist.
+      expect(body.sources).toEqual({ releases: 'ok', prImages: 'rate-limited' })
+      await plugin.stop()
+    })
+
+    it('records a generic error (not rate-limited) when /pulls rejects', async () => {
       stubFetch((url) => {
         if (url.includes('/releases')) {
           return okJson([{ tag_name: 'v3.4.0', prerelease: false, draft: false }])
@@ -791,14 +902,13 @@ describe('mayara-server-signalk-plugin container integration', () => {
       await handler({}, res)
 
       expect(res.statusCode).toBe(200)
-      const body = res.body as { tag: string }[]
-      expect(body).toContainEqual({ tag: 'v3.4.0', prerelease: false })
-      expect(body.some((v) => v.tag.startsWith('pr'))).toBe(false)
+      const body = res.body as { sources: { releases: string; prImages: string } }
+      expect(body.sources).toEqual({ releases: 'ok', prImages: 'error' })
       await plugin.stop()
     })
 
-    it('returns 502 when both sources are down', async () => {
-      stubFetch(() => Promise.resolve({ ok: false, json: () => Promise.resolve([]) }))
+    it('returns 502 with per-source status when both sources are rate-limited', async () => {
+      stubFetch(() => rateLimited())
 
       const { router, plugin } = await loadPlugin()
       const handler = getHandler(router, 'GET /api/versions')
@@ -806,6 +916,104 @@ describe('mayara-server-signalk-plugin container integration', () => {
       await handler({}, res)
 
       expect(res.statusCode).toBe(502)
+      const body = res.body as { error: string; sources: { releases: string; prImages: string } }
+      expect(body.sources).toEqual({ releases: 'rate-limited', prImages: 'rate-limited' })
+      await plugin.stop()
+    })
+
+    it('sends an Authorization header on both calls when a GitHub token is set', async () => {
+      process.env.GITHUB_TOKEN = 'ghp_test'
+      stubFetch(() => okJson([]))
+
+      const { router, plugin } = await loadPlugin()
+      const handler = getHandler(router, 'GET /api/versions')
+      await handler({}, makeRes())
+
+      expect(fetchCalls).toHaveLength(2)
+      for (const call of fetchCalls) {
+        expect(call.init?.headers?.Authorization).toBe('Bearer ghp_test')
+        expect(call.init?.headers?.Accept).toBe('application/vnd.github+json')
+      }
+      await plugin.stop()
+    })
+
+    it('sends no Authorization header when no GitHub token is available', async () => {
+      stubFetch(() => okJson([]))
+
+      const { router, plugin } = await loadPlugin()
+      const handler = getHandler(router, 'GET /api/versions')
+      await handler({}, makeRes())
+
+      expect(fetchCalls).toHaveLength(2)
+      for (const call of fetchCalls) {
+        expect(call.init?.headers?.Authorization).toBeUndefined()
+      }
+      await plugin.stop()
+    })
+
+    it('retries without the token when a present token is rejected (401), so a bad token is never worse than none', async () => {
+      process.env.GITHUB_TOKEN = 'ghp_expired'
+      // Authenticated calls 401; the unauthenticated retry succeeds. The
+      // retry must return the shape matching each URL (releases vs pulls),
+      // or the pulls handler would choke on release-shaped data.
+      stubFetch((url, init) => {
+        const headers = (init as { headers?: Record<string, string> } | undefined)?.headers
+        const authed = !!headers?.Authorization
+        if (authed) {
+          return Promise.resolve({
+            ok: false,
+            status: 401,
+            headers: { get: () => null },
+            json: () => Promise.resolve([])
+          })
+        }
+        if (url.includes('/releases')) {
+          return okJson([{ tag_name: 'v3.4.0', prerelease: false, draft: false }])
+        }
+        return okJson([])
+      })
+
+      const { router, plugin } = await loadPlugin()
+      const handler = getHandler(router, 'GET /api/versions')
+      const res = makeRes()
+      await handler({}, res)
+
+      // 2 authenticated + 2 retries = 4 calls; the last two carry no auth.
+      expect(fetchCalls).toHaveLength(4)
+      const retries = fetchCalls.filter((c) => !c.init?.headers?.Authorization)
+      expect(retries).toHaveLength(2)
+      // The retry populated the list — strictly better than the 502 the
+      // un-retried authenticated 401s would have produced.
+      expect(res.statusCode).toBe(200)
+      const body = res.body as { versions: { tag: string }[]; sources: { releases: string } }
+      expect(body.versions).toContainEqual({ tag: 'v3.4.0', prerelease: false })
+      expect(body.sources.releases).toBe('ok')
+      await plugin.stop()
+    })
+
+    it('classifies a non-rate-limit failure (500) as error, not rate-limited', async () => {
+      // 500 with no x-ratelimit-remaining header must NOT be mislabeled
+      // "rate-limited, retry shortly" — that would tell the operator to
+      // wait when the real problem is a server error.
+      stubFetch((url) => {
+        if (url.includes('/releases')) {
+          return okJson([{ tag_name: 'v3.4.0', prerelease: false, draft: false }])
+        }
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          headers: { get: () => null },
+          json: () => Promise.resolve([])
+        })
+      })
+
+      const { router, plugin } = await loadPlugin()
+      const handler = getHandler(router, 'GET /api/versions')
+      const res = makeRes()
+      await handler({}, res)
+
+      const body = res.body as { sources: { releases: string; prImages: string } }
+      expect(body.sources).toEqual({ releases: 'ok', prImages: 'error' })
       await plugin.stop()
     })
   })

--- a/test/signalk-token.test.ts
+++ b/test/signalk-token.test.ts
@@ -17,6 +17,7 @@ import {
   beginTokenRequest,
   deleteCachedToken,
   readCachedToken,
+  readGithubToken,
   validateCachedToken,
   writeCachedToken
 } from '../src/signalk-token'
@@ -110,6 +111,66 @@ describe('signalk-token: cache helpers', () => {
     expect(() => {
       deleteCachedToken(dataDir)
     }).not.toThrow()
+  })
+})
+
+describe('signalk-token: readGithubToken', () => {
+  // CI injects GITHUB_TOKEN; isolate the env so these cases are
+  // deterministic regardless of the runner, and restore it afterward.
+  let savedGithubToken: string | undefined
+  let savedGhToken: string | undefined
+  beforeEach(() => {
+    savedGithubToken = process.env.GITHUB_TOKEN
+    savedGhToken = process.env.GH_TOKEN
+    delete process.env.GITHUB_TOKEN
+    delete process.env.GH_TOKEN
+  })
+  afterEach(() => {
+    if (savedGithubToken === undefined) delete process.env.GITHUB_TOKEN
+    else process.env.GITHUB_TOKEN = savedGithubToken
+    if (savedGhToken === undefined) delete process.env.GH_TOKEN
+    else process.env.GH_TOKEN = savedGhToken
+  })
+
+  it('returns undefined when nothing is set', () => {
+    expect(readGithubToken(dataDir)).toBeUndefined()
+  })
+
+  it('prefers GITHUB_TOKEN over GH_TOKEN and over the file', () => {
+    process.env.GITHUB_TOKEN = 'from-github-env'
+    process.env.GH_TOKEN = 'from-gh-env'
+    writeFileSync(join(dataDir, 'github-token'), 'from-file')
+    expect(readGithubToken(dataDir)).toBe('from-github-env')
+  })
+
+  it('falls back to GH_TOKEN when GITHUB_TOKEN is unset', () => {
+    process.env.GH_TOKEN = 'from-gh-env'
+    writeFileSync(join(dataDir, 'github-token'), 'from-file')
+    expect(readGithubToken(dataDir)).toBe('from-gh-env')
+  })
+
+  it('falls back to GH_TOKEN when GITHUB_TOKEN is whitespace-only (not masked)', () => {
+    // A whitespace-only GITHUB_TOKEN must not short-circuit the fallback
+    // and silently revert to unauthenticated — that would re-expose the
+    // rate-limit exhaustion this token exists to cure.
+    process.env.GITHUB_TOKEN = '   '
+    process.env.GH_TOKEN = 'valid-gh-token'
+    expect(readGithubToken(dataDir)).toBe('valid-gh-token')
+  })
+
+  it('reads the github-token file when no env var is set', () => {
+    writeFileSync(join(dataDir, 'github-token'), '  ghp_fromfile\n')
+    expect(readGithubToken(dataDir)).toBe('ghp_fromfile')
+  })
+
+  it('trims env whitespace', () => {
+    process.env.GITHUB_TOKEN = '  ghp_padded  '
+    expect(readGithubToken(dataDir)).toBe('ghp_padded')
+  })
+
+  it('treats an empty/whitespace file as absent', () => {
+    writeFileSync(join(dataDir, 'github-token'), '   \n')
+    expect(readGithubToken(dataDir)).toBeUndefined()
   })
 })
 

--- a/test/versionsView.test.ts
+++ b/test/versionsView.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { deriveVersionsView, shownTags, runningTagFallback } from '../src/configpanel/versionsView'
+import {
+  deriveVersionsView,
+  shownTags,
+  runningTagFallback,
+  splitVersions
+} from '../src/configpanel/versionsView'
 
 describe('versionsView: deriveVersionsView', () => {
   it('full success: returns the versions and no error line', () => {
@@ -110,5 +115,34 @@ describe('versionsView: runningTagFallback', () => {
     expect(set.has('v3.4.0')).toBe(true)
     expect(set.has('v3.5.0')).toBe(false)
     expect(runningTagFallback('v3.5.0', many)).toBe('v3.5.0')
+  })
+})
+
+describe('versionsView: splitVersions', () => {
+  // Shared by the panel's <optgroup> render AND shownTags, so both agree
+  // on the slice limits (5 stable, 3 pre-release).
+  it('buckets PR / stable / pre-release with the rendered slice limits', () => {
+    const versions = [
+      ...Array.from({ length: 7 }, (_, i) => ({ tag: `v3.${i}.0`, prerelease: false })),
+      ...Array.from({ length: 4 }, (_, i) => ({ tag: `v4.0.0-rc${i}`, prerelease: true })),
+      { tag: 'pr429', pr: 429, title: 'x' }
+    ]
+    const { prVersions, stableVersions, preVersions } = splitVersions(versions)
+    expect(prVersions.map((v) => v.tag)).toEqual(['pr429'])
+    expect(stableVersions).toHaveLength(5)
+    expect(preVersions).toHaveLength(3)
+  })
+
+  it('is the exact source of shownTags membership', () => {
+    const versions = [
+      { tag: 'v3.4.0', prerelease: false },
+      { tag: 'v4.0.0-rc0', prerelease: true },
+      { tag: 'pr429', pr: 429, title: 'x' }
+    ]
+    const { prVersions, stableVersions, preVersions } = splitVersions(versions)
+    const set = shownTags(versions)
+    for (const v of [...prVersions, ...stableVersions, ...preVersions]) {
+      expect(set.has(v.tag)).toBe(true)
+    }
   })
 })

--- a/test/versionsView.test.ts
+++ b/test/versionsView.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest'
+import { deriveVersionsView, shownTags, runningTagFallback } from '../src/configpanel/versionsView'
+
+describe('versionsView: deriveVersionsView', () => {
+  it('full success: returns the versions and no error line', () => {
+    const v = deriveVersionsView(true, {
+      versions: [
+        { tag: 'v3.4.0', prerelease: false },
+        { tag: 'pr429', pr: 429, title: 'north-up fix' }
+      ],
+      sources: { releases: 'ok', prImages: 'ok' }
+    })
+    expect(v.versions).toEqual([
+      { tag: 'v3.4.0', prerelease: false },
+      { tag: 'pr429', pr: 429, title: 'north-up fix' }
+    ])
+    expect(v.versionsError).toBe('')
+  })
+
+  it('rate-limited pulls (the boat bug): keeps releases, shows the rate-limit line', () => {
+    const v = deriveVersionsView(true, {
+      versions: [{ tag: 'v3.4.0', prerelease: false }],
+      sources: { releases: 'ok', prImages: 'rate-limited' }
+    })
+    expect(v.versions).toEqual([{ tag: 'v3.4.0', prerelease: false }])
+    expect(v.versionsError).toMatch(/rate-limited/)
+    // Distinct from a generic error so the operator knows to retry, not
+    // that no PR images exist.
+    expect(v.versionsError).toContain('PR test images')
+  })
+
+  it('generic error is distinct from rate-limited', () => {
+    const v = deriveVersionsView(true, {
+      versions: [{ tag: 'v3.4.0', prerelease: false }],
+      sources: { releases: 'ok', prImages: 'error' }
+    })
+    expect(v.versionsError).toContain('Could not fetch')
+    expect(v.versionsError).not.toMatch(/rate-limited/)
+  })
+
+  it('rate-limited releases (not prImages) does not falsely blame PR test images', () => {
+    const v = deriveVersionsView(true, {
+      versions: [],
+      sources: { releases: 'rate-limited', prImages: 'ok' }
+    })
+    expect(v.versionsError).toMatch(/rate-limited/)
+    expect(v.versionsError).toContain('some versions')
+    expect(v.versionsError).not.toContain('PR test images')
+  })
+
+  it('does not throw on a malformed 200 body (null / non-object / missing fields)', () => {
+    for (const body of [null, undefined, 42, 'nope', {}]) {
+      const v = deriveVersionsView(true, body)
+      expect(v.versions).toEqual([])
+      expect(v.versionsError).toBe('')
+    }
+  })
+
+  it('502 (both down): null versions so the caller preserves its list, plus a last-known line', () => {
+    const v = deriveVersionsView(false, null)
+    expect(v.versions).toBeNull()
+    expect(v.versionsError).toContain('last known')
+  })
+
+  it('legacy bare-array body is accepted (backend/panel version skew)', () => {
+    const v = deriveVersionsView(true, [{ tag: 'v3.4.0', prerelease: false }])
+    expect(v.versions).toEqual([{ tag: 'v3.4.0', prerelease: false }])
+    expect(v.versionsError).toBe('')
+  })
+
+  it('missing versions/sources fields degrade to empty list, no error', () => {
+    expect(deriveVersionsView(true, {}).versions).toEqual([])
+    expect(deriveVersionsView(true, {}).versionsError).toBe('')
+  })
+})
+
+describe('versionsView: runningTagFallback', () => {
+  const versions = [
+    { tag: 'v3.4.0', prerelease: false },
+    { tag: 'v3.5.0-rc1', prerelease: true },
+    { tag: 'pr429', pr: 429, title: 'x' }
+  ]
+
+  it('returns null for a tag already shown (real option — no duplicate)', () => {
+    expect(runningTagFallback('pr429', versions)).toBeNull()
+    expect(runningTagFallback('v3.4.0', versions)).toBeNull()
+    expect(runningTagFallback('latest', versions)).toBeNull()
+    expect(runningTagFallback('main', versions)).toBeNull()
+  })
+
+  it('returns the running tag when it is NOT among the shown options', () => {
+    // pr427 was rate-limited out of the /pulls fetch but is running.
+    expect(runningTagFallback('pr427', versions)).toBe('pr427')
+    // a stable pin that fell out of the top-N.
+    expect(runningTagFallback('v3.0.0', versions)).toBe('v3.0.0')
+  })
+
+  it('returns null for an empty/undefined running tag', () => {
+    expect(runningTagFallback('', versions)).toBeNull()
+    expect(runningTagFallback(undefined, versions)).toBeNull()
+  })
+
+  it('shownTags reflects the same top-N slicing the dropdown renders', () => {
+    const many = Array.from({ length: 10 }, (_, i) => ({
+      tag: `v3.${i}.0`,
+      prerelease: false
+    }))
+    const set = shownTags(many)
+    // Only the first 5 stable versions render, so the 6th is a fallback.
+    expect(set.has('v3.4.0')).toBe(true)
+    expect(set.has('v3.5.0')).toBe(false)
+    expect(runningTagFallback('v3.5.0', many)).toBe('v3.5.0')
+  })
+})


### PR DESCRIPTION
## Summary

The config panel's version dropdown lost its PR test images, and the **Check** button failed with `GitHub API 429`, when GitHub rate-limited the plugin's unauthenticated REST calls. A boat sharing a WAN IP with other GitHub-polling plugins exhausts the 60-req/hr unauthenticated limit (and trips GitHub's stickier 429 secondary/abuse limit, which lingers for hours), so both the dropdown's `/api/versions` calls and signalk-container's update-check source returned errors and the PR images vanished.

Two GitHub paths existed, both unauthenticated: the plugin's own `/api/versions` (dropdown) and the `githubReleases` update source the plugin registers with signalk-container (Check button). This change authenticates both.

- Read an **optional** GitHub token — `GITHUB_TOKEN` / `GH_TOKEN` env, or a `github-token` file in the plugin data dir — and pass it to both paths. A token lifts the limit to 5000/hr, curing the exhaustion. The token is optional and **not** a user-facing config field; absent, the calls stay unauthenticated with no regression. It lives in `signalk-token.ts` because the repo forbids `fs` imports in `index.ts` (guard test). A whitespace-only `GITHUB_TOKEN` no longer masks a valid `GH_TOKEN`, and a present-but-rejected token (401) retries once unauthenticated, so a bad token is never worse than none.
- Stop silently blanking the PR images on a rate-limit. `/api/versions` returns `{versions, sources}` with each source classified `ok` / `rate-limited` / `error` (reading the rate-limit response headers). The panel shows a dedicated line distinguishing a rate-limit (retry shortly) from a generic fetch error, so the operator can tell that from "no PR images exist". The message names the PR-images source specifically only when that is the source that failed.
- A running `pr<N>` whose fetch was rate-limited keeps a synthetic `(running)` dropdown option instead of blank-resetting the selection.

The panel decision logic (parse, error-line, running-option) is extracted to `versionsView.js` so it is unit-tested without a DOM; a colocated `.d.ts` keeps the plain-JS module (webpack/babel resolves `.js`) typed for the TS tests.

## Tested

- `npm run build:all` — lint + build + 132 unit tests, all pass. `npm run format:check` clean.
- New tests: token precedence (`GITHUB_TOKEN` > `GH_TOKEN` > file, whitespace not masking), file/env sourcing, `/api/versions` auth-header on both calls, no-header without a token, 401 retry-without-auth, `/pulls` rate-limited → 200 with `sources.prImages: 'rate-limited'` (the boat bug), both-down → 502, 500 classifies as `error` not `rate-limited`, update-source registration passes the token (and `undefined` when absent), and the extracted `versionsView` decisions across all response shapes incl. a malformed body.
- Verified live: with the rate limit reset, `/api/versions` returns `pr429` with `sources` `ok`/`ok`; the built `plugin/index.js` feeds `readGithubToken` into both GitHub paths.
- `fs`-import guard on `index.ts` still passes (token reader is in `signalk-token.ts`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds GitHub authentication to both version lookup paths: `/api/versions` and the `githubReleases` update-check source. The plugin now reads an optional token from `GITHUB_TOKEN`, `GH_TOKEN`, or a `github-token` file in the data directory, uses it when present, and retries unauthenticated if GitHub rejects the token with 401.

`/api/versions` now surfaces per-source status for releases and PR images as `ok`, `rate-limited`, or `error` instead of silently clearing results on rate-limit failures. The response includes both `versions` and `sources`, and the panel shows a dedicated rate-limit message while keeping a synthetic running tag option when a running `pr<N>` image is rate-limited.

Version rendering logic moves into `versionsView.js`, which derives the displayed versions, error text, shown tags, and running-tag fallback behavior. The panel uses this helper to preserve prior versions on fetch failure and render version-status messages under the dropdown.

Adds and updates unit/integration coverage for GitHub token lookup, authenticated fetch/retry behavior, `/api/versions` source classification, and the version dropdown view logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->