### PR TITLE
chore(release): 1.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "signalk-plugin-enabled-by-default": true,


### PR DESCRIPTION
## Summary

Patch release bundling the merged GitHub rate-limit resilience fix (#84).

Since v1.4.2:

- **fix(versions):** authenticate the plugin's GitHub REST calls with an optional token (`GITHUB_TOKEN` / `GH_TOKEN` / `github-token` file) so the version dropdown's PR test images and the "Check" update button no longer fail when GitHub rate-limits a boat sharing a WAN IP. Rate-limit failures (including GitHub's secondary/abuse 429) are now surfaced to the operator instead of silently blanking the list, and a running `pr<N>` stays selectable. (#84)

Version bump only; no code changes in this PR.