### PR TITLE
chore(release): 1.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "signalk-plugin-enabled-by-default": true,


### PR DESCRIPTION
## Summary

Patch release bundling the radar-discovery fixes that landed since 1.4.3:

- `getRadarInfo` now forwards mayara's color legend so consumers can color spoke samples, and the full control set (gain, sea, rain, range, ...) instead of only gain.
- gain and sea default `auto: false` when mayara omits the flag, so their required shape always holds.
- Non-numeric controls (enum/list controls like targetTrails, mode; boolean on/off controls) now forward verbatim instead of being silently dropped.

## Tested

- `npm run build:all` green — lint, build, 138 tests pass.