### PR TITLE
v3.4.0 radar API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,7 +190,7 @@ The mayara GUI is proxied through Signal K at `/plugins/<id>/gui/` so only the S
 
 ## Dependencies
 
-- Signal K Server ≥ 2.24.0 (Radar API requirement)
+- Signal K Server ≥ 2.31.0 (v3.4.0 Radar API requirement; the lean `RadarInfo` and the `{ version, radars }` list land in 2.31.0)
 - signalk-container ≥ 1.6.0 (declared in `signalk.requires`; intentionally **not** an npm `peerDependency`. It's a cross-plugin runtime dependency discovered at runtime via `globalThis.__signalk_containerManager` and installed through Signal K's appstore, not something npm should resolve. Declaring it as a peer made npm enforce the version range, which broke `@beta`/prerelease installs with ERESOLVE because npm excludes prereleases from plain `>=` ranges.)
 - Node ≥ engines floor in `package.json` (CI matrix tests Node 22 and 24)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A SignalK plugin that connects to [mayara-server](https://github.com/MarineYacht
 
 ## Prerequisites
 
-- **SignalK Server ≥ 2.24.0** (the Radar API ships in 2.24.0+)
+- **SignalK Server ≥ 2.31.0** (the v3.4.0 Radar API this plugin implements ships in 2.31.0+)
 - **Node.js ≥ 22** (tested on Node 22 and 24)
 - **[signalk-container](https://github.com/dirkwa/signalk-container) ≥ 1.6.0** (for managed container mode, optional)
 - **Podman** or **Docker** runtime (for managed container mode)
@@ -165,7 +165,7 @@ npm run build
 
 - **[mayara-server](https://github.com/MarineYachtRadar/mayara-server)** — Standalone radar server
 - **[signalk-container](https://github.com/dirkwa/signalk-container)** — Container manager for SignalK
-- **[Signal K Server](https://github.com/SignalK/signalk-server)** ≥ 2.24.0 — provides the Radar API
+- **[Signal K Server](https://github.com/SignalK/signalk-server)** ≥ 2.31.0 — provides the v3.4.0 Radar API
 
 ## License
 

--- a/docs/api-divergence.md
+++ b/docs/api-divergence.md
@@ -1,0 +1,282 @@
+# Radar API divergence: mayara-server vs. signalk-server vs. this plugin
+
+**Date:** 2026-07-19
+**Observed against:** mayara-server 3.6.0 (`http://10.56.0.1:6502`), signalk-server
+2.30.0 with this plugin (`http://10.56.0.147:3000`), a Navico HALO24 (dual range
+`nav1034A` / `nav1034B`).
+
+While building an OpenCPN client (`mayara_pi`) against the Signal K Radar API, it
+became clear that three things implement/serve "the radar API" and they do not
+agree with each other — nor with the spec document that ships in the
+signalk-server repo. This note records the concrete differences so they can be
+reconciled.
+
+## The three components
+
+1. **mayara-server** — the standalone Rust server. Reference implementation of
+   the Signal K Radar API per `signalk-server/docs/develop/rest-api/radar_api.md`.
+2. **signalk-server radar API** — `signalk-server/src/api/radar/` (framework +
+   REST/AsyncAPI surface) that a provider plugin registers with.
+3. **this plugin** (`mayara-server-signalk-plugin`) — bridges mayara-server into
+   signalk-server. It has two distinct code paths:
+   - `radar-provider.ts` registers radars with the signalk-server radar API, and
+     `spoke-forwarder.ts` forwards mayara's spokes into signalk-server's
+     `binaryStreamManager`.
+   - a `guiProxy` (`index.ts`, `router.use('/gui', …)`) that proxies
+     mayara-server's _own_ HTTP API/GUI and rewrites stream URLs.
+
+## Comparison
+
+| Aspect                                    | mayara-server (:6502)                                   | signalk-server radar API (:3000)                                                                                                  | this plugin                                                                                                            |
+| ----------------------------------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Radar **list** shape                      | keyed object `{ "nav1034A": {…} }`                      | **array** `[ { "id": "nav1034A", … } ]`                                                                                           | proxy assumes **keyed** (`Object.values`, `index.ts`)                                                                  |
+| `spokeDataUrl` / `streamUrl` in list      | present                                                 | **absent**                                                                                                                        | present + rewritten (`index.ts` `rewriteStreamUrl`)                                                                    |
+| spoke-length field                        | `maxSpokeLength`                                        | list: `maxSpokeLen`; capabilities: `maxSpokeLength`                                                                               | —                                                                                                                      |
+| `capabilities`                            | spec format                                             | same spec format (incl. `legend.pixels`)                                                                                          | proxied                                                                                                                |
+| **spoke stream** (binary, `spokeDataUrl`) | `…/radars/{id}/spokes` binary protobuf WS               | binary forwarding **implemented but mis-pathed at `…/radars/{id}/stream`** (`src/api/streams/index.ts`), not the spec's `/spokes` | emits into `binaryStreamManager` (streamId `radars/{id}`) — client-exposed by that endpoint                            |
+| **control stream** (JSON, `streamUrl`)    | `radars.{id}.controls.*` deltas on `/signalk/v1/stream` | the standard SK delta/PUT stream **already exists**; it just carries no `radars.*` yet                                            | subscribes to mayara's v1 stream but **filters to notifications only** — radar deltas not republished, no PUT handlers |
+
+Re-verified 2026-07-19 against the current `../signalk-server` tree (`radar_api.md`
+last touched Jun 21, commit `9cd2ebe0` "Radar API refactored"; impl predates it):
+every row above still holds unchanged **except the stream rows, corrected below**
+— the original single-row claim that "the spoke stream is unimplemented / not
+client-exposed" was wrong, _and_ it conflated two very different transports.
+
+### Correction: two streams, and neither needs new signalk-server WS infra
+
+A radar exposes **two independent streams**, and they are unrelated transports —
+do not model them as one endpoint at two paths.
+
+1. **`spokeDataUrl` → `…/radars/{id}/spokes`** — one-way **binary** protobuf spoke
+   image data, high-frequency, server → client. The radar picture.
+2. **`streamUrl` → `/signalk/v1/stream`** — the **standard Signal K delta/PUT
+   stream**, _not_ a radar-specific socket. Radar state is modelled as Signal K
+   paths (`radars.{id}.controls.*`, target data); a client subscribes for
+   control-value / target deltas and sends Signal K **PUTs** to change controls.
+   This is confirmed by observation (2026-07-20): mayara publishes the full
+   control set — `radars.nav1034A.controls.{gain,power,range,sea,rain,mode,
+doppler,targetTrails,…}` (both radars, plus `meta`) — on its own
+   `ws://…/signalk/v1/stream`, exactly the URL its `/signalk` discovery advertises
+   as `signalk-ws`.
+
+**Binary (`/spokes`) already works — just at the wrong path.** The infrastructure
+lives in a _different_ module than the radar API:
+
+- `initializeBinaryStreams()` (`src/api/streams/index.ts`, wired at
+  `src/api/index.ts:70`) installs a server-level `upgrade` listener serving the
+  generic `…/api/streams/{streamId}` and the radar alias
+  `…/api/vessels/self/radars/{id}/stream` → streamId `radars/{id}`.
+- `BinaryStreamManager` (`src/api/streams/binary-stream-manager.ts`) fans frames
+  out to all clients with a 256 KB-per-client backpressure cap and slow-consumer
+  disconnect — production-grade, not a stub.
+- This plugin's `spoke-forwarder.ts` already emits to that streamId, so binary
+  spokes reach a client **through signalk-server** today — but the alias is named
+  `/stream`, so it is serving _binary_ on a path whose name implies the control
+  channel. It must move to `/spokes`.
+
+**Control (`streamUrl`) needs no new signalk-server endpoint — the bridge is
+plugin-side.** Signal K's `/signalk/v1/stream` already does deltas (out) and PUTs
+(in); the gap is purely that radar data is not bridged across it:
+
+- **mayara → SK (state out).** The plugin already connects to mayara's v1 stream
+  but `notification-forwarder.ts` **filters to `notifications.*`**, so SK's
+  `/signalk/v1/stream` carries **no `radars.*` paths** (verified: 98 messages, none).
+  Widening the forwarder to also republish `radars.*` deltas via
+  `app.handleMessage()` (stamping the proper `context`) surfaces live radar state
+  to every SK subscriber.
+- **SK → mayara (control in).** A client changes a control with a Signal K PUT
+  (over the v1 stream or REST). The plugin registers
+  `app.registerPutHandler('vessels.self', 'radars.<id>.controls.<control>', …)`
+  and forwards to mayara's `PUT /…/radars/{id}/controls/{control}` — which
+  `MayaraClient.setControl` already calls and mayara already serves.
+
+Caveat: mayara's own `/signalk/v1/stream` is only loosely SK-conformant — its
+hello omits `self` and its deltas omit `context` (MarineYachtRadar/mayara-server#462).
+The plugin re-stamps `context` when republishing via `app.handleMessage()`, so this
+is invisible to clients consuming radar data _through_ signalk-server; it only bites
+a client pointed directly at mayara's stream.
+
+So the control "stream" is standard Signal K plumbing the plugin bridges, not a
+WebSocket signalk-server has to grow. The stale `radar/index.ts:812` note
+("providers should expose their own streamUrl") points readers away from the
+`streams/` module and should be fixed to reference `/spokes` (binary, in
+`streams/`) and `/signalk/v1/stream` (control, standard SK).
+
+**Fourth representation (added on re-verification).** signalk-server does not have
+one shape and one spec — it has _four_ representations that disagree:
+
+1. `radar_api.md` (hand-written spec): keyed `{ version, radars: { id: RadarInfo } }`,
+   lean `RadarInfo` (`name/brand/model?/radarIpAddress/spokeDataUrl/streamUrl`),
+   `maxSpokeLength`, `/spokes`.
+2. `src/api/radar/openApi.ts` (machine OpenAPI served at `/admin/openapi`): `RadarInfo`
+   requires `name/brand/spokeDataUrl/streamUrl/radarIpAddress` — the _lean_ shape,
+   matching the markdown, **not** the array the server actually emits.
+3. `packages/server-api/src/radarapi.ts` + `typebox/radar-schemas.ts` (the exported
+   TypeScript type / TypeBox schema): rich `RadarInfo`
+   (`id/status/spokesPerRevolution/maxSpokeLen/range/controls/legend?/streamUrl?`),
+   no `spokeDataUrl`, `streamUrl` optional.
+4. `src/api/radar/index.ts` (the running code): returns a bare **array** of the rich
+   `RadarInfo` from #3. (The binary spoke WS _is_ implemented, but in the separate
+   `src/api/streams/` module at `/stream`, not `/spokes` — see the stream correction
+   above.)
+
+So the two docs (#1, #2) describe the lean/keyed shape; the type and the code (#3, #4)
+are the rich/array shape. Only #3 and #4 agree with each other.
+
+### Observed responses
+
+mayara-server list (keyed, with URLs):
+
+```json
+{
+  "nav1034A": {
+    "brand": "Navico",
+    "model": "HALO24",
+    "name": "Halo;",
+    "radarIpAddress": "10.56.0.102",
+    "spokeDataUrl": "ws://10.56.0.1:6502/signalk/v2/api/vessels/self/radars/nav1034A/spokes",
+    "streamUrl": "ws://10.56.0.1:6502/signalk/v1/stream",
+    "replay": false
+  }
+}
+```
+
+signalk-server list (array, no URLs, `maxSpokeLen`):
+
+```json
+[
+  {
+    "id": "nav1034A",
+    "name": "Halo;",
+    "brand": "Navico",
+    "status": "transmit",
+    "spokesPerRevolution": 2048,
+    "maxSpokeLen": 1024,
+    "range": 115,
+    "controls": { "gain": { "auto": true, "value": 80 } }
+  }
+]
+```
+
+Note the same signalk-server returns `maxSpokeLength` from
+`…/radars/nav1034A/capabilities` but `maxSpokeLen` in the list above — an
+inconsistency _within_ one server.
+
+## The three specific mismatches
+
+1. **Spec vs. implementation, same repo.** `radar_api.md` (v3.1.0, in the
+   signalk-server repo) documents the _keyed_ object, `spokeDataUrl`, and
+   `/spokes` — which matches **mayara-server exactly**. signalk-server's actual
+   `src/api/radar` implementation emits the _array_ shape and omits the URLs. So
+   the implementation diverges from its own spec.
+
+2. **Two streams: binary mis-pathed, control not bridged.** A radar has a **binary
+   spoke** stream (`spokeDataUrl` → `/spokes`) and a **control/target** stream
+   (`streamUrl` → the standard SK `/signalk/v1/stream`) — see the correction above.
+   signalk-server forwards the _binary_ one (via `src/api/streams/`, fed by this
+   plugin) but names it `/stream`, so it must move to `/spokes`. The control stream
+   is not a missing endpoint — SK's v1 delta/PUT stream already exists and mayara
+   already publishes `radars.{id}.controls.*` on its own — it is simply not bridged:
+   this plugin's forwarder filters to `notifications.*`, and no PUT handlers are
+   registered. The `radar/index.ts:812` note points away from the `streams/` module
+   that already implements the binary transport.
+
+3. **The plugin speaks two dialects.** `radar-provider.ts` feeds signalk-server's
+   (array) API; `guiProxy` proxies mayara-server's (keyed) API for the embedded
+   GUI. Even inside the plugin there are two shapes.
+
+## Impact on clients
+
+A spec-conforming client (e.g. `mayara_pi`) connecting to `/spokes` for the binary
+image gets a 404 today and cannot tell the feature is merely at a different path —
+the working binary endpoint is `/stream`. A client wanting control state/PUTs over
+Signal K's `/signalk/v1/stream` finds no `radars.*` paths there (the plugin doesn't
+bridge them). The list also omits `spokeDataUrl`. `mayara_pi` currently works around
+the binary case by being dialect-tolerant — it parses both list shapes, uses
+`spokeDataUrl` when present
+and otherwise constructs the URL from the host per the spec, verifies the spoke
+WebSocket actually opens, and falls back to connecting to mayara-server directly
+when it does not.
+
+## Chosen direction: converge the implementation onto the spec
+
+Decision (2026-07-19): make signalk-server's **implementation match `radar_api.md`**
+(which mayara-server already implements), rather than rewriting the spec to describe
+the current rich/array code. This keeps the reference spec, mayara-server, and
+`mayara_pi` on one shape; signalk-server is the component that moves.
+
+This is a **breaking change to the exported `@signalk/server-api` `RadarProviderMethods`
+contract** — every radar provider plugin (not just this one) must update, not only
+signalk-server internals.
+
+### What "match the spec" concretely means
+
+It is **not** a field rename. The spec's list is _lean_ (discovery-only); the current
+impl's list is _rich_ (state crammed into every entry). Converging means reverting the
+`#2357` rich-list refactor's data model:
+
+1. **List shape.** `GET /radars` returns `{ version, radars: Record<string, RadarInfo> }`
+   (keyed object, wrapped) instead of a bare `RadarInfo[]`.
+2. **`RadarInfo` goes lean.** `{ name, brand, model?, radarIpAddress, spokeDataUrl,
+streamUrl }`. The fields dropped from the list — `status`, `range`, `controls`,
+   `spokesPerRevolution`, `maxSpokeLength` — already have homes: `status`/`controls`
+   at `/radars/{id}/state` and `/controls`, and `spokesPerRevolution`/`maxSpokeLength`
+   at `/radars/{id}/capabilities`.
+3. **Two stream URLs, both optional, different transports.** `spokeDataUrl` is the
+   binary spoke WS; `streamUrl` is the **standard Signal K delta/PUT stream**
+   (`/signalk/v1/stream`) carrying `radars.{id}.controls.*` and target data. The old
+   type conflated them into one optional `streamUrl`; they are now split. Both are
+   **optional**: absent means signalk-server serves it (spokes via the binary stream
+   manager at `/spokes`; control via its own `/signalk/v1/stream`) and the client
+   constructs the URL from the host. This is the key enabler for remote/containerised
+   providers — clients reach the data through signalk-server with only its port
+   exposed. Present means an external URL for direct connection.
+4. **Two endpoints, two jobs — but only one is signalk-server work.** (a) **Binary
+   `/spokes`** — move the existing binary forwarding from `/stream` to `/spokes` on
+   the `src/api/streams/` upgrade listener and realign `asyncApi.ts`. A rename of a
+   working transport, not new infrastructure. (b) **Control `/signalk/v1/stream`** —
+   **no signalk-server endpoint is needed**: SK's v1 stream already does deltas (out)
+   and PUTs (in), and mayara already models controls as `radars.{id}.controls.*` on
+   its own v1 stream (observed 2026-07-20). The gap is purely the plugin-side bridge:
+   widen `notification-forwarder.ts` (currently `notifications.*`-only) to also
+   republish `radars.*` deltas, and register `app.registerPutHandler(...)` for
+   `radars.<id>.controls.*` that forwards to mayara's control PUT. Also fix the stale
+   `radar/index.ts:812` note to reference `/spokes` and `/signalk/v1/stream`.
+5. **Field naming.** `maxSpokeLength` consistently (it leaves the list entirely and
+   lives only in `/capabilities`, where it is already spelled `maxSpokeLength`, so the
+   `maxSpokeLen` spelling disappears with the lean list).
+
+### Consequence: `GET /radars` no longer shows status/range/controls
+
+The central behavioural consequence. A client that renders a radar list with live
+status today (one call) will, after convergence, need `GET /radars` for discovery
+**plus** `GET /radars/{id}/state` per radar for status/range/controls. This is the
+spec's intended separation (static discovery vs dynamic state vs capabilities), and it
+is what mayara-server already does — the divergence doc's mayara list sample above is
+exactly this lean shape — but it is a real regression in list convenience versus the
+current rich array, and the reason the `#2357` refactor went the other way.
+
+### Files touched (3 repos, breaking)
+
+| #   | Repo / file                                                                         | Change                                                                                                                                                                                                                          | Status                                                  |
+| --- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| 1   | `signalk-server` `packages/server-api/src/radarapi.ts` + `typebox/radar-schemas.ts` | Replace rich `RadarInfo` with the lean spec shape; add `RadarsResponse { version, radars }`; split into optional `spokeDataUrl` + `streamUrl`                                                                                   | **done** (branch `radar-lean-radarinfo-type`, unpushed) |
+| 2   | `signalk-server` `src/api/radar/index.ts`                                           | `getRadars()` builds the keyed `{ version, radars }` object; stop cramming state into list entries                                                                                                                              | todo                                                    |
+| 3   | `signalk-server` `src/api/radar/openApi.ts`                                         | Wrap the list response; it is already lean, so mostly response-envelope alignment                                                                                                                                               | todo                                                    |
+| 4a  | `signalk-server` `src/api/streams/index.ts` + `src/api/radar/asyncApi.ts`           | Move the binary spoke forwarding from `/stream` to `/spokes` on the upgrade listener; realign `asyncApi.ts`; fix the stale `radar/index.ts:812` note                                                                            | todo                                                    |
+| 4b  | **this plugin** `notification-forwarder.ts` (or a new forwarder)                    | Widen the mayara→SK forwarder to republish `radars.*` deltas, not just `notifications.*`, so radar state appears on SK's `/signalk/v1/stream`                                                                                   | todo                                                    |
+| 4c  | **this plugin** `src/index.ts` + `radar-provider.ts`                                | Register `app.registerPutHandler` for `radars.<id>.controls.*` → forward to mayara control PUT (SK→mayara control-in)                                                                                                           | todo                                                    |
+| 5   | **this plugin** `src/radar-provider.ts` + tests                                     | `getRadarInfo` returns the lean object (`name`/`brand`/`model?`/`radarIpAddress`); may omit `spokeDataUrl`/`streamUrl` so clients use signalk-server's forwarded endpoints; status/range/controls already covered by `getState` | todo                                                    |
+
+Per this repo's PR discipline these are separate PRs, sequenced server-api →
+signalk-server impl → plugin, because #1 breaks the type every consumer compiles
+against. Only **4a** is signalk-server stream work (a small binary-path rename — the
+transport already works). The control stream (**4b/4c**) is **entirely plugin-side**
+over Signal K's existing v1 delta/PUT stream; signalk-server needs no new WebSocket
+endpoint.
+
+### Until convergence lands
+
+Keep clients dialect-tolerant: parse both list shapes, use `spokeDataUrl` when present
+and otherwise construct it from the host per the spec, and verify the spoke WebSocket
+actually opens before relying on it (falling back to a direct mayara-server connection).

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "engines": {
     "node": ">=22",
-    "signalk": ">=2.24.0"
+    "signalk": ">=2.31.0"
   },
   "dependencies": {
     "@sinclair/typebox": "^0.34.0",
@@ -57,7 +57,7 @@
     "@babel/core": "^7.29.0",
     "@babel/preset-react": "^7.28.5",
     "@eslint/js": "^10.0.1",
-    "@signalk/server-api": "^2.24.0",
+    "@signalk/server-api": "^2.31.0",
     "@types/express": "^5.0.0",
     "@types/node": "^22.0.0",
     "@types/ws": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@babel/core": "^7.29.0",
     "@babel/preset-react": "^7.28.5",
     "@eslint/js": "^10.0.1",
-    "@signalk/server-api": "^2.31.0",
+    "@signalk/server-api": "^2.31.0-beta.1",
     "@types/express": "^5.0.0",
     "@types/node": "^22.0.0",
     "@types/ws": "^8.5.0",

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -181,12 +181,30 @@ module.exports = function (app) {
                     return raw;
                 }
             };
+            // mayara base URL for the GUI's own assets and mayara-specific endpoints.
+            const mayaraBase = () => {
+                const host = currentSettings?.host ?? 'localhost';
+                const port = currentSettings?.port ?? 6502;
+                const proto = currentSettings?.secure ? 'https' : 'http';
+                return `${proto}://${host}:${port}`;
+            };
             const guiProxy = (0, http_proxy_middleware_1.createProxyMiddleware)({
-                router: () => {
-                    const host = currentSettings?.host ?? 'localhost';
-                    const port = currentSettings?.port ?? 6502;
-                    const proto = currentSettings?.secure ? 'https' : 'http';
-                    return `${proto}://${host}:${port}`;
+                router: (req) => {
+                    // Radar data — the radar REST API, the control stream, and the spoke
+                    // stream — is all served under `/signalk/...` by the Signal K server
+                    // this plugin registered with. Point those requests at the local SK
+                    // loopback so the proxied GUI runs against full Signal K, proving the
+                    // radar API behaves identically either way. Everything else (the GUI's
+                    // own static assets and mayara-specific `/v2` recordings/debug) goes to
+                    // mayara. Requests carry the `/plugins/<id>/gui` mount stripped, so the
+                    // path here is e.g. `/signalk/v2/...` or `/viewer.js`.
+                    const path = req.url ?? '';
+                    if (path === '/signalk' || path.startsWith('/signalk/')) {
+                        const sk = resolveSignalkLoopback();
+                        const httpScheme = sk.scheme === 'wss' ? 'https' : 'http';
+                        return `${httpScheme}://127.0.0.1:${sk.port}`;
+                    }
+                    return mayaraBase();
                 },
                 // `router.use('/gui', guiProxy)` strips the `/gui` prefix
                 // before the middleware sees the request, so the proxy
@@ -197,6 +215,9 @@ module.exports = function (app) {
                 // API roots through and only prefixes genuine assets with `/gui`.
                 target: 'http://localhost:6502', // overridden by `router`
                 changeOrigin: true,
+                // Accept the Signal K loopback's self-signed cert when SK runs on https
+                // (the token flow connects the same way). No-op for the http targets.
+                secure: false,
                 // Do NOT let the middleware auto-subscribe to the server's `upgrade`
                 // event. It would see the raw `/plugins/<id>/gui/signalk/...` URL,
                 // which `pathRewrite` can't strip the mount prefix from (it only

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -962,6 +962,16 @@ module.exports = function (app) {
             notificationForwarder = new notification_forwarder_1.NotificationForwarder(app, {
                 pluginId: PLUGIN_ID,
                 url: client.getStateStreamUrl(),
+                // Relay both guard-zone notifications and radar control/target state
+                // (radars.{id}.controls.*) onto the host SK server's own v1 stream, so
+                // a client subscribed there sees live radar state without connecting to
+                // mayara directly. This is the "out" half of the Radar API control
+                // stream; the "in" half (control changes) is the PUT handlers below.
+                subscriptions: [
+                    { path: 'notifications.*', policy: 'instant' },
+                    { path: 'radars.*', policy: 'instant' }
+                ],
+                pathPrefixes: ['notifications.', 'radars.'],
                 debug: app.debug.bind(app),
                 reconnectInterval: (settings.reconnectInterval || 5) * 1000
             });
@@ -1076,6 +1086,13 @@ module.exports = function (app) {
                 else {
                     app.debug('binaryStreamManager not available - spoke streaming disabled');
                 }
+                // Register Signal K PUT handlers for this radar's controls, so a client
+                // can change a control by PUTting radars.<id>.controls.<control> on the
+                // host SK server (over the v1 stream or REST) and have it forwarded to
+                // mayara — the "in" half of the Radar API control stream. Fire-and-forget:
+                // it fetches the control list from mayara. Re-registration on a later
+                // rediscovery is idempotent (same source overwrites).
+                void registerControlPutHandlers(radarId);
             }
         }
         for (const radarId of knownRadars) {
@@ -1088,6 +1105,41 @@ module.exports = function (app) {
                     spokeForwarders.delete(radarId);
                 }
             }
+        }
+    }
+    // Register a Signal K PUT handler for every control mayara reports on a radar,
+    // at path radars.<id>.controls.<control>. Each handler forwards the put value
+    // verbatim to mayara's control PUT (the same call the Radar API's REST
+    // setControl uses), so a value read off the v1 stream can be echoed back to
+    // change it. Read-only controls (modelName, firmwareVersion, …) get a handler
+    // too, but mayara rejects the write. Registration is idempotent on rediscovery
+    // because the source (PLUGIN_ID) key overwrites.
+    async function registerControlPutHandlers(radarId) {
+        if (!client)
+            return;
+        try {
+            const controls = await client.getControls(radarId);
+            const controlIds = Object.keys(controls);
+            for (const controlId of controlIds) {
+                const path = `radars.${radarId}.controls.${controlId}`;
+                app.registerPutHandler('vessels.self', path, (_context, _path, value, cb) => {
+                    if (!client)
+                        return { state: 'FAILED', statusCode: 503 };
+                    client
+                        .setControl(radarId, controlId, value)
+                        .then(() => {
+                        cb({ state: 'COMPLETED', statusCode: 200 });
+                    })
+                        .catch((err) => {
+                        cb({ state: 'COMPLETED', statusCode: 400, message: errMsg(err) });
+                    });
+                    return { state: 'PENDING' };
+                }, PLUGIN_ID);
+            }
+            app.debug(`Registered ${controlIds.length} control PUT handler(s) for ${radarId}`);
+        }
+        catch (err) {
+            app.debug(`Failed to register PUT handlers for ${radarId}: ${errMsg(err)}`);
         }
     }
     async function pollForRadarChanges(settings) {

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -235,14 +235,16 @@ module.exports = function (app) {
                         if (ct.includes('application/json') &&
                             req.url?.includes('/signalk/v2/api/vessels/self/radars')) {
                             try {
-                                const json = JSON.parse(buffer.toString('utf8'));
-                                for (const radar of Object.values(json)) {
+                                const parsed = JSON.parse(buffer.toString('utf8'));
+                                const json = parsed;
+                                const radars = json.radars ?? json;
+                                for (const radar of Object.values(radars)) {
                                     if (radar.streamUrl)
                                         radar.streamUrl = rewriteStreamUrl(radar.streamUrl);
                                     if (radar.spokeDataUrl)
                                         radar.spokeDataUrl = rewriteStreamUrl(radar.spokeDataUrl);
                                 }
-                                return Promise.resolve(JSON.stringify(json));
+                                return Promise.resolve(JSON.stringify(parsed));
                             }
                             catch {
                                 return Promise.resolve(buffer);

--- a/plugin/mayara-client.js
+++ b/plugin/mayara-client.js
@@ -98,13 +98,20 @@ class MayaraClient {
         return `${wsProtocol}://${this.host}:${this.port}${API_BASE}/${radarId}/targets/stream`;
     }
     /**
-     * Signal K v1 stream — the same WebSocket the built-in GUI subscribes
-     * to. Used by NotificationForwarder to listen for `notifications.*`
-     * deltas (e.g. guard-zone alarms) and republish them upstream.
+     * mayara's Signal K v1 stream. Used by NotificationForwarder to relay
+     * `notifications.*` and `radars.*` deltas upstream.
+     *
+     * `?subscribe=none` is deliberate: under Signal K's subscription model the
+     * default (`self`) streams own-ship `navigation.*` too, but the plugin must
+     * NOT forward nav — mayara only has it because it received it from Signal K
+     * in the first place, so re-publishing it would loop it back. Starting from
+     * `none` and letting the forwarder subscribe to exactly `radars.*` /
+     * `notifications.*` keeps nav (and AIS) out, and stays correct whether mayara
+     * treats a later subscribe as additive (SK-compliant) or narrowing.
      */
     getStateStreamUrl() {
         const wsProtocol = this.secure ? 'wss' : 'ws';
-        return `${wsProtocol}://${this.host}:${this.port}/signalk/v1/stream`;
+        return `${wsProtocol}://${this.host}:${this.port}/signalk/v1/stream?subscribe=none`;
     }
     close() {
         // No persistent connections to close for HTTP client

--- a/plugin/mayara-client.js
+++ b/plugin/mayara-client.js
@@ -63,7 +63,12 @@ class MayaraClient {
         });
     }
     async getRadars() {
-        return (await this.request('GET', API_BASE));
+        const response = (await this.request('GET', API_BASE));
+        // mayara returns the `{ version, radars }` envelope; unwrap to the bare
+        // `{ id: RadarInfo }` map so callers can key by radar id (and `Object.keys`
+        // yields radar ids, not `version`/`radars`). Tolerate an older bare response.
+        const radars = response.radars;
+        return (radars && typeof radars === 'object' ? radars : response);
     }
     async getCapabilities(radarId) {
         return this.request('GET', `${API_BASE}/${radarId}/capabilities`);

--- a/plugin/radar-provider.js
+++ b/plugin/radar-provider.js
@@ -1,31 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.createRadarProvider = createRadarProvider;
-// mayara serves its color legend inside /capabilities as `legend.pixels`, an array indexed by pixel
-// value where each entry is `{ color, type }`. Map it to the Radar API `LegendEntry[]` so consumers can
-// color spoke samples; the array index is the sample value, so each entry bounds itself to that value.
-function mapLegend(capabilities) {
-    const legend = capabilities.legend;
-    const pixels = legend ? legend.pixels : undefined;
-    if (!Array.isArray(pixels))
-        return undefined;
-    const entries = [];
-    pixels.forEach((pixel, index) => {
-        if (typeof pixel !== 'object' || pixel === null)
-            return;
-        const color = pixel.color;
-        if (typeof color !== 'string')
-            return;
-        const type = pixel.type;
-        entries.push({
-            color,
-            label: typeof type === 'string' ? type : `level ${index}`,
-            minValue: index,
-            maxValue: index
-        });
-    });
-    return entries.length > 0 ? entries : undefined;
-}
 // The controls the Radar API types as auto-capable (RadarControlValue, a required boolean auto), as
 // opposed to value-only controls like rain. gain and sea must always carry a boolean auto.
 const AUTO_CAPABLE_CONTROLS = new Set(['gain', 'sea']);
@@ -77,27 +52,28 @@ function createRadarProvider(client, app) {
                 const radarEntry = radars[radarId];
                 if (!radarEntry)
                     return null;
-                const controls = await client.getControls(radarId);
-                const capabilities = (await client.getCapabilities(radarId));
-                const powerCtrl = controls.power;
-                const rangeCtrl = controls.range;
-                const status = powerCtrl?.value === 2 ? 'transmit' : powerCtrl?.value === 1 ? 'standby' : 'off';
-                const legend = mapLegend(capabilities);
-                return {
-                    id: radarId,
+                // Lean discovery object per radar_api.md: identify the radar only. Live
+                // state (status, controls) is served by getState/getControls, and static
+                // parameters (spokesPerRevolution, maxSpokeLength, legend) by
+                // getCapabilities — so nothing is lost, it just moves off the list.
+                const brand = typeof radarEntry.brand === 'string' ? radarEntry.brand : 'Unknown';
+                const model = typeof radarEntry.model === 'string' ? radarEntry.model : undefined;
+                const info = {
                     name: typeof radarEntry.name === 'string'
                         ? radarEntry.name
-                        : typeof radarEntry.model === 'string'
-                            ? `${typeof radarEntry.brand === 'string' ? radarEntry.brand : ''} ${radarEntry.model}`.trim()
+                        : model
+                            ? `${brand === 'Unknown' ? '' : brand} ${model}`.trim()
                             : radarId,
-                    brand: typeof radarEntry.brand === 'string' ? radarEntry.brand : 'Unknown',
-                    status: status,
-                    spokesPerRevolution: Number(capabilities.spokesPerRevolution || 2048),
-                    maxSpokeLen: Number(capabilities.maxSpokeLength || 512),
-                    range: Number(rangeCtrl?.value ?? 1852),
-                    controls: mapControls(controls),
-                    ...(legend ? { legend } : {})
+                    brand,
+                    radarIpAddress: typeof radarEntry.radarIpAddress === 'string' ? radarEntry.radarIpAddress : ''
                 };
+                if (model)
+                    info.model = model;
+                // spokeDataUrl / streamUrl are intentionally omitted so clients use
+                // signalk-server's own endpoints (…/radars/{id}/spokes and
+                // /signalk/v1/stream), which reach the radar through this plugin even
+                // when mayara runs on another host or container.
+                return info;
             }
             catch (err) {
                 debug(`getRadarInfo error for ${radarId}: ${err instanceof Error ? err.message : String(err)}`);
@@ -122,7 +98,11 @@ function createRadarProvider(client, app) {
                     id: radarId,
                     timestamp: new Date().toISOString(),
                     status: status,
-                    controls: controls
+                    // Normalise mayara's controls the way the discovery list used to
+                    // (auto flags on gain/sea, gain default) — now that the lean
+                    // RadarInfo carries no controls, /state and /controls are where
+                    // clients read them.
+                    controls: mapControls(controls)
                 };
             }
             catch (err) {

--- a/plugin/radar-provider.js
+++ b/plugin/radar-provider.js
@@ -1,38 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.createRadarProvider = createRadarProvider;
-// The controls the Radar API types as auto-capable (RadarControlValue, a required boolean auto), as
-// opposed to value-only controls like rain. gain and sea must always carry a boolean auto.
-const AUTO_CAPABLE_CONTROLS = new Set(['gain', 'sea']);
-// Forward every control mayara reports (gain, sea, rain, range, mode, targetTrails, ...) rather than only
-// gain, so the discovery RadarInfo carries the full current control state mayara already returned. Values
-// pass through as-is: numbers for level controls, but also strings for enum/list controls (mayara serves
-// these as their label, e.g. targetTrails "Medium") and booleans for on/off controls. The auto flag is
-// preserved where the radar reports one, and defaulted to false for the auto-capable controls (gain, sea)
-// when mayara omits it — but only when their value is numeric, so a string-valued control never gets a
-// spurious auto stapled on. The SK RadarControls index signature has no slot for non-numeric values, so
-// the accumulator is widened and the final cast bridges to the API type.
-function mapControls(controls) {
-    const out = {};
-    for (const [id, entry] of Object.entries(controls)) {
-        if (typeof entry !== 'object' || entry === null)
-            continue;
-        if (!('value' in entry))
-            continue;
-        const value = entry.value;
-        const auto = entry.auto;
-        if (typeof value === 'number' && typeof auto === 'boolean')
-            out[id] = { auto, value };
-        else if (typeof value === 'number' && AUTO_CAPABLE_CONTROLS.has(id))
-            out[id] = { auto: false, value };
-        else
-            out[id] = { value };
-    }
-    // A radar that reports no gain still gets a sane default, as before.
-    if (!('gain' in out))
-        out.gain = { auto: true, value: 50 };
-    return out;
-}
 function createRadarProvider(client, app) {
     const debug = app.debug.bind(app);
     return {
@@ -98,11 +66,12 @@ function createRadarProvider(client, app) {
                     id: radarId,
                     timestamp: new Date().toISOString(),
                     status: status,
-                    // Normalise mayara's controls the way the discovery list used to
-                    // (auto flags on gain/sea, gain default) — now that the lean
-                    // RadarInfo carries no controls, /state and /controls are where
-                    // clients read them.
-                    controls: mapControls(controls)
+                    // Forward mayara's controls verbatim. mayara already reports each
+                    // control the way the Radar API expects — auto-capable controls
+                    // (gain/sea/…) always carry a boolean `auto`, enum/list controls carry
+                    // their label string — so no normalisation is needed here, and /state
+                    // and /controls stay byte-identical to mayara's own responses.
+                    controls: controls
                 };
             }
             catch (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -216,12 +216,31 @@ module.exports = function (app: MayaraServerAPI): Plugin {
         }
       }
 
+      // mayara base URL for the GUI's own assets and mayara-specific endpoints.
+      const mayaraBase = (): string => {
+        const host = currentSettings?.host ?? 'localhost'
+        const port = currentSettings?.port ?? 6502
+        const proto = currentSettings?.secure ? 'https' : 'http'
+        return `${proto}://${host}:${port}`
+      }
+
       const guiProxy: RequestHandler = createProxyMiddleware({
-        router: () => {
-          const host = currentSettings?.host ?? 'localhost'
-          const port = currentSettings?.port ?? 6502
-          const proto = currentSettings?.secure ? 'https' : 'http'
-          return `${proto}://${host}:${port}`
+        router: (req: IncomingMessage) => {
+          // Radar data — the radar REST API, the control stream, and the spoke
+          // stream — is all served under `/signalk/...` by the Signal K server
+          // this plugin registered with. Point those requests at the local SK
+          // loopback so the proxied GUI runs against full Signal K, proving the
+          // radar API behaves identically either way. Everything else (the GUI's
+          // own static assets and mayara-specific `/v2` recordings/debug) goes to
+          // mayara. Requests carry the `/plugins/<id>/gui` mount stripped, so the
+          // path here is e.g. `/signalk/v2/...` or `/viewer.js`.
+          const path = req.url ?? ''
+          if (path === '/signalk' || path.startsWith('/signalk/')) {
+            const sk = resolveSignalkLoopback()
+            const httpScheme = sk.scheme === 'wss' ? 'https' : 'http'
+            return `${httpScheme}://127.0.0.1:${sk.port}`
+          }
+          return mayaraBase()
         },
         // `router.use('/gui', guiProxy)` strips the `/gui` prefix
         // before the middleware sees the request, so the proxy
@@ -232,6 +251,9 @@ module.exports = function (app: MayaraServerAPI): Plugin {
         // API roots through and only prefixes genuine assets with `/gui`.
         target: 'http://localhost:6502', // overridden by `router`
         changeOrigin: true,
+        // Accept the Signal K loopback's self-signed cert when SK runs on https
+        // (the token flow connects the same way). No-op for the http targets.
+        secure: false,
         // Do NOT let the middleware auto-subscribe to the server's `upgrade`
         // event. It would see the raw `/plugins/<id>/gui/signalk/...` URL,
         // which `pathRewrite` can't strip the mount prefix from (it only

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Plugin } from '@signalk/server-api'
+import { Plugin, ActionResult } from '@signalk/server-api'
 import { Request, Response, IRouter } from 'express'
 import { type IncomingMessage } from 'http'
 import { Server as NetServer, type Socket } from 'net'
@@ -1128,6 +1128,16 @@ module.exports = function (app: MayaraServerAPI): Plugin {
       notificationForwarder = new NotificationForwarder(app, {
         pluginId: PLUGIN_ID,
         url: client.getStateStreamUrl(),
+        // Relay both guard-zone notifications and radar control/target state
+        // (radars.{id}.controls.*) onto the host SK server's own v1 stream, so
+        // a client subscribed there sees live radar state without connecting to
+        // mayara directly. This is the "out" half of the Radar API control
+        // stream; the "in" half (control changes) is the PUT handlers below.
+        subscriptions: [
+          { path: 'notifications.*', policy: 'instant' },
+          { path: 'radars.*', policy: 'instant' }
+        ],
+        pathPrefixes: ['notifications.', 'radars.'],
         debug: app.debug.bind(app),
         reconnectInterval: (settings.reconnectInterval || 5) * 1000
       })
@@ -1252,6 +1262,14 @@ module.exports = function (app: MayaraServerAPI): Plugin {
         } else {
           app.debug('binaryStreamManager not available - spoke streaming disabled')
         }
+
+        // Register Signal K PUT handlers for this radar's controls, so a client
+        // can change a control by PUTting radars.<id>.controls.<control> on the
+        // host SK server (over the v1 stream or REST) and have it forwarded to
+        // mayara — the "in" half of the Radar API control stream. Fire-and-forget:
+        // it fetches the control list from mayara. Re-registration on a later
+        // rediscovery is idempotent (same source overwrites).
+        void registerControlPutHandlers(radarId)
       }
     }
 
@@ -1266,6 +1284,49 @@ module.exports = function (app: MayaraServerAPI): Plugin {
           spokeForwarders.delete(radarId)
         }
       }
+    }
+  }
+
+  // Register a Signal K PUT handler for every control mayara reports on a radar,
+  // at path radars.<id>.controls.<control>. Each handler forwards the put value
+  // verbatim to mayara's control PUT (the same call the Radar API's REST
+  // setControl uses), so a value read off the v1 stream can be echoed back to
+  // change it. Read-only controls (modelName, firmwareVersion, …) get a handler
+  // too, but mayara rejects the write. Registration is idempotent on rediscovery
+  // because the source (PLUGIN_ID) key overwrites.
+  async function registerControlPutHandlers(radarId: string): Promise<void> {
+    if (!client) return
+    try {
+      const controls = await client.getControls(radarId)
+      const controlIds = Object.keys(controls)
+      for (const controlId of controlIds) {
+        const path = `radars.${radarId}.controls.${controlId}`
+        app.registerPutHandler(
+          'vessels.self',
+          path,
+          (
+            _context: string,
+            _path: string,
+            value: unknown,
+            cb: (r: ActionResult) => void
+          ): ActionResult => {
+            if (!client) return { state: 'FAILED', statusCode: 503 }
+            client
+              .setControl(radarId, controlId, value)
+              .then(() => {
+                cb({ state: 'COMPLETED', statusCode: 200 })
+              })
+              .catch((err: unknown) => {
+                cb({ state: 'COMPLETED', statusCode: 400, message: errMsg(err) })
+              })
+            return { state: 'PENDING' }
+          },
+          PLUGIN_ID
+        )
+      }
+      app.debug(`Registered ${controlIds.length} control PUT handler(s) for ${radarId}`)
+    } catch (err) {
+      app.debug(`Failed to register PUT handlers for ${radarId}: ${errMsg(err)}`)
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,15 +272,19 @@ module.exports = function (app: MayaraServerAPI): Plugin {
               req.url?.includes('/signalk/v2/api/vessels/self/radars')
             ) {
               try {
-                const json = JSON.parse(buffer.toString('utf8')) as Record<
-                  string,
-                  { streamUrl?: string; spokeDataUrl?: string }
-                >
-                for (const radar of Object.values(json)) {
+                const parsed: unknown = JSON.parse(buffer.toString('utf8'))
+                // mayara's list is the `{ version, radars }` envelope (matching
+                // the signalk-server Radar API); tolerate a bare keyed map too.
+                type RadarEntry = { streamUrl?: string; spokeDataUrl?: string }
+                const json = parsed as {
+                  radars?: Record<string, RadarEntry>
+                } & Record<string, RadarEntry>
+                const radars: Record<string, RadarEntry> = json.radars ?? json
+                for (const radar of Object.values(radars)) {
                   if (radar.streamUrl) radar.streamUrl = rewriteStreamUrl(radar.streamUrl)
                   if (radar.spokeDataUrl) radar.spokeDataUrl = rewriteStreamUrl(radar.spokeDataUrl)
                 }
-                return Promise.resolve(JSON.stringify(json))
+                return Promise.resolve(JSON.stringify(parsed))
               } catch {
                 return Promise.resolve(buffer)
               }

--- a/src/mayara-client.ts
+++ b/src/mayara-client.ts
@@ -72,7 +72,12 @@ export class MayaraClient {
   }
 
   async getRadars(): Promise<Record<string, unknown>> {
-    return (await this.request('GET', API_BASE)) as Record<string, unknown>
+    const response = (await this.request('GET', API_BASE)) as Record<string, unknown>
+    // mayara returns the `{ version, radars }` envelope; unwrap to the bare
+    // `{ id: RadarInfo }` map so callers can key by radar id (and `Object.keys`
+    // yields radar ids, not `version`/`radars`). Tolerate an older bare response.
+    const radars = response.radars
+    return (radars && typeof radars === 'object' ? radars : response) as Record<string, unknown>
   }
 
   async getCapabilities(radarId: string): Promise<unknown> {

--- a/src/mayara-client.ts
+++ b/src/mayara-client.ts
@@ -121,13 +121,20 @@ export class MayaraClient {
   }
 
   /**
-   * Signal K v1 stream — the same WebSocket the built-in GUI subscribes
-   * to. Used by NotificationForwarder to listen for `notifications.*`
-   * deltas (e.g. guard-zone alarms) and republish them upstream.
+   * mayara's Signal K v1 stream. Used by NotificationForwarder to relay
+   * `notifications.*` and `radars.*` deltas upstream.
+   *
+   * `?subscribe=none` is deliberate: under Signal K's subscription model the
+   * default (`self`) streams own-ship `navigation.*` too, but the plugin must
+   * NOT forward nav — mayara only has it because it received it from Signal K
+   * in the first place, so re-publishing it would loop it back. Starting from
+   * `none` and letting the forwarder subscribe to exactly `radars.*` /
+   * `notifications.*` keeps nav (and AIS) out, and stays correct whether mayara
+   * treats a later subscribe as additive (SK-compliant) or narrowing.
    */
   getStateStreamUrl(): string {
     const wsProtocol = this.secure ? 'wss' : 'ws'
-    return `${wsProtocol}://${this.host}:${this.port}/signalk/v1/stream`
+    return `${wsProtocol}://${this.host}:${this.port}/signalk/v1/stream?subscribe=none`
   }
 
   close(): void {

--- a/src/notification-forwarder.ts
+++ b/src/notification-forwarder.ts
@@ -21,6 +21,19 @@ export interface NotificationForwarderOptions {
   pluginId: string
   /** ws:// URL of mayara-server's `/signalk/v1/stream` endpoint. */
   url: string
+  /**
+   * Subscriptions sent to mayara on connect. Defaults to
+   * `[{ path: 'notifications.*', policy: 'instant' }]`. Pass a wider set to
+   * also relay radar state, e.g. add `{ path: 'radars.*', policy: 'instant' }`.
+   */
+  subscriptions?: Array<{ path: string; policy: string }>
+  /**
+   * Path prefixes whose value entries are republished upstream. A delta value
+   * survives if its `path` starts with any prefix. Defaults to
+   * `['notifications.']`. Add `'radars.'` to bridge radar control/target state
+   * onto the host Signal K server's own `/signalk/v1/stream`.
+   */
+  pathPrefixes?: string[]
   /** Optional logger; defaults to a no-op. */
   debug?: (msg: string) => void
   reconnectInterval?: number
@@ -33,21 +46,29 @@ export interface NotificationForwarderOptions {
 }
 
 /**
- * Bridges `notifications.*` deltas from mayara-server's Signal K v1
- * stream into the host Signal K server via `app.handleMessage`. Mayara
- * emits e.g. `notifications.radar.<key>.guardZone.<n>` on its own
- * stream; without this forwarder, those alarms reach mayara's built-in
- * GUI but not the SK admin notifications panel, the chart plotter, or
- * any other SK consumer.
+ * Bridges deltas from mayara-server's Signal K v1 stream into the host
+ * Signal K server via `app.handleMessage`, so mayara's data appears on the
+ * host's own `/signalk/v1/stream`. Which paths are relayed is configurable
+ * (`pathPrefixes` / `subscriptions`); by default only `notifications.*`.
  *
- * On connect we send a `notifications.*` subscription so mayara filters
- * appropriately. Each incoming delta is forwarded as-is — mayara has
- * already shaped it to the SK spec (state / method / message), and the
- * SK server stamps `$source` from `pluginId` on republish.
+ * Two use cases:
+ * - `notifications.*` (default): guard-zone alarms etc., so they reach the SK
+ *   admin notifications panel, the chart plotter, and other SK consumers.
+ * - `radars.*` (opt-in): radar control/target state modelled as
+ *   `radars.{id}.controls.*` — mayara publishes these on its own stream;
+ *   relaying them surfaces live radar state on the host stream, the control
+ *   half of the Radar API's `streamUrl` (the PUT half is registerPutHandler).
+ *
+ * On connect we send the configured subscriptions so mayara filters
+ * appropriately. Each incoming delta is forwarded as-is — mayara has already
+ * shaped it to the SK spec — and the SK server stamps `$source` from
+ * `pluginId` and `context` = self on republish.
  */
 export class NotificationForwarder {
   private readonly pluginId: string
   private readonly url: string
+  private readonly subscriptions: Array<{ path: string; policy: string }>
+  private readonly pathPrefixes: string[]
   private readonly debug: (msg: string) => void
   private readonly reconnectMs: number
   private readonly webSocketFactory: (url: string) => WebSocketLike
@@ -62,6 +83,8 @@ export class NotificationForwarder {
     this.app = app
     this.pluginId = options.pluginId
     this.url = options.url
+    this.subscriptions = options.subscriptions ?? [{ path: 'notifications.*', policy: 'instant' }]
+    this.pathPrefixes = options.pathPrefixes ?? ['notifications.']
     this.debug = options.debug ?? (() => {})
     this.reconnectMs = options.reconnectInterval ?? 5000
     this.webSocketFactory =
@@ -86,12 +109,10 @@ export class NotificationForwarder {
         this.connected = true
         this.debug('Connected to mayara notification stream')
 
-        // Tell mayara we only care about notification deltas. Using a
-        // wildcard means we pick up every radar's guard-zone alarms (and
-        // any future per-radar notification types mayara adds) without
-        // having to know radar ids up front.
+        // Tell mayara which deltas we want. Wildcards mean we pick up every
+        // radar's alarms/state without having to know radar ids up front.
         const subscription = JSON.stringify({
-          subscribe: [{ path: 'notifications.*', policy: 'instant' }]
+          subscribe: this.subscriptions
         })
         try {
           ws.send(subscription)
@@ -152,24 +173,22 @@ export class NotificationForwarder {
       return
     }
 
-    const delta = this.extractNotificationDelta(parsed)
+    const delta = this.extractDelta(parsed)
     if (!delta) return
 
     try {
       this.app.handleMessage(this.pluginId, delta)
     } catch (err) {
-      this.debug(
-        `Failed to forward notification delta: ${err instanceof Error ? err.message : String(err)}`
-      )
+      this.debug(`Failed to forward delta: ${err instanceof Error ? err.message : String(err)}`)
     }
   }
 
   /**
-   * Returns a copy of `parsed` containing only the notification values.
-   * Returns null if `parsed` isn't a Signal K delta, has no `updates`,
-   * or carries no `notifications.*` paths after filtering.
+   * Returns a copy of `parsed` containing only the value entries whose `path`
+   * matches one of the configured prefixes. Returns null if `parsed` isn't a
+   * Signal K delta, has no `updates`, or carries no matching paths.
    */
-  private extractNotificationDelta(parsed: unknown): Partial<Delta> | null {
+  private extractDelta(parsed: unknown): Partial<Delta> | null {
     if (!parsed || typeof parsed !== 'object') return null
     const root = parsed as { updates?: unknown[] }
     if (!Array.isArray(root.updates)) return null
@@ -180,20 +199,22 @@ export class NotificationForwarder {
       const values = (update as { values?: unknown[] }).values
       if (!Array.isArray(values)) continue
 
-      const notificationValues = values.filter((v) => {
+      const matchingValues = values.filter((v) => {
         if (!v || typeof v !== 'object') return false
         const path = (v as { path?: unknown }).path
-        return typeof path === 'string' && path.startsWith('notifications.')
+        return (
+          typeof path === 'string' && this.pathPrefixes.some((prefix) => path.startsWith(prefix))
+        )
       })
 
-      if (notificationValues.length > 0) {
+      if (matchingValues.length > 0) {
         // Preserve $source / timestamp from upstream; the SK server
         // will overlay `$source = <pluginId>` on its own, but the
-        // upstream timestamp is the moment the alarm fired and is
+        // upstream timestamp is the moment the value changed and is
         // worth keeping.
         filteredUpdates.push({
           ...update,
-          values: notificationValues
+          values: matchingValues
         })
       }
     }

--- a/src/radar-provider.ts
+++ b/src/radar-provider.ts
@@ -2,29 +2,6 @@ import { radar } from '@signalk/server-api'
 import { MayaraClient } from './mayara-client'
 import { MayaraServerAPI } from './types'
 
-// mayara serves its color legend inside /capabilities as `legend.pixels`, an array indexed by pixel
-// value where each entry is `{ color, type }`. Map it to the Radar API `LegendEntry[]` so consumers can
-// color spoke samples; the array index is the sample value, so each entry bounds itself to that value.
-function mapLegend(capabilities: Record<string, unknown>): radar.LegendEntry[] | undefined {
-  const legend = capabilities.legend as { pixels?: unknown } | undefined
-  const pixels = legend ? legend.pixels : undefined
-  if (!Array.isArray(pixels)) return undefined
-  const entries: radar.LegendEntry[] = []
-  pixels.forEach((pixel, index) => {
-    if (typeof pixel !== 'object' || pixel === null) return
-    const color = (pixel as { color?: unknown }).color
-    if (typeof color !== 'string') return
-    const type = (pixel as { type?: unknown }).type
-    entries.push({
-      color,
-      label: typeof type === 'string' ? type : `level ${index}`,
-      minValue: index,
-      maxValue: index
-    })
-  })
-  return entries.length > 0 ? entries : undefined
-}
-
 // The controls the Radar API types as auto-capable (RadarControlValue, a required boolean auto), as
 // opposed to value-only controls like rain. gain and sea must always carry a boolean auto.
 const AUTO_CAPABLE_CONTROLS = new Set(['gain', 'sea'])
@@ -77,32 +54,29 @@ export function createRadarProvider(
         const radarEntry = radars[radarId] as Record<string, unknown> | undefined
         if (!radarEntry) return null
 
-        const controls = await client.getControls(radarId)
-        const capabilities = (await client.getCapabilities(radarId)) as Record<string, unknown>
-
-        const powerCtrl = controls.power as Record<string, unknown> | undefined
-        const rangeCtrl = controls.range as Record<string, unknown> | undefined
-        const status =
-          powerCtrl?.value === 2 ? 'transmit' : powerCtrl?.value === 1 ? 'standby' : 'off'
-
-        const legend = mapLegend(capabilities)
-
-        return {
-          id: radarId,
+        // Lean discovery object per radar_api.md: identify the radar only. Live
+        // state (status, controls) is served by getState/getControls, and static
+        // parameters (spokesPerRevolution, maxSpokeLength, legend) by
+        // getCapabilities — so nothing is lost, it just moves off the list.
+        const brand = typeof radarEntry.brand === 'string' ? radarEntry.brand : 'Unknown'
+        const model = typeof radarEntry.model === 'string' ? radarEntry.model : undefined
+        const info: radar.RadarInfo = {
           name:
             typeof radarEntry.name === 'string'
               ? radarEntry.name
-              : typeof radarEntry.model === 'string'
-                ? `${typeof radarEntry.brand === 'string' ? radarEntry.brand : ''} ${radarEntry.model}`.trim()
+              : model
+                ? `${brand === 'Unknown' ? '' : brand} ${model}`.trim()
                 : radarId,
-          brand: typeof radarEntry.brand === 'string' ? radarEntry.brand : 'Unknown',
-          status: status as radar.RadarStatus,
-          spokesPerRevolution: Number(capabilities.spokesPerRevolution || 2048),
-          maxSpokeLen: Number(capabilities.maxSpokeLength || 512),
-          range: Number(rangeCtrl?.value ?? 1852),
-          controls: mapControls(controls),
-          ...(legend ? { legend } : {})
+          brand,
+          radarIpAddress:
+            typeof radarEntry.radarIpAddress === 'string' ? radarEntry.radarIpAddress : ''
         }
+        if (model) info.model = model
+        // spokeDataUrl / streamUrl are intentionally omitted so clients use
+        // signalk-server's own endpoints (…/radars/{id}/spokes and
+        // /signalk/v1/stream), which reach the radar through this plugin even
+        // when mayara runs on another host or container.
+        return info
       } catch (err) {
         debug(
           `getRadarInfo error for ${radarId}: ${err instanceof Error ? err.message : String(err)}`
@@ -133,7 +107,11 @@ export function createRadarProvider(
           id: radarId,
           timestamp: new Date().toISOString(),
           status: status as radar.RadarStatus,
-          controls: controls
+          // Normalise mayara's controls the way the discovery list used to
+          // (auto flags on gain/sea, gain default) — now that the lean
+          // RadarInfo carries no controls, /state and /controls are where
+          // clients read them.
+          controls: mapControls(controls)
         }
       } catch (err) {
         debug(`getState error for ${radarId}: ${err instanceof Error ? err.message : String(err)}`)

--- a/src/radar-provider.ts
+++ b/src/radar-provider.ts
@@ -2,35 +2,6 @@ import { radar } from '@signalk/server-api'
 import { MayaraClient } from './mayara-client'
 import { MayaraServerAPI } from './types'
 
-// The controls the Radar API types as auto-capable (RadarControlValue, a required boolean auto), as
-// opposed to value-only controls like rain. gain and sea must always carry a boolean auto.
-const AUTO_CAPABLE_CONTROLS = new Set(['gain', 'sea'])
-
-// Forward every control mayara reports (gain, sea, rain, range, mode, targetTrails, ...) rather than only
-// gain, so the discovery RadarInfo carries the full current control state mayara already returned. Values
-// pass through as-is: numbers for level controls, but also strings for enum/list controls (mayara serves
-// these as their label, e.g. targetTrails "Medium") and booleans for on/off controls. The auto flag is
-// preserved where the radar reports one, and defaulted to false for the auto-capable controls (gain, sea)
-// when mayara omits it — but only when their value is numeric, so a string-valued control never gets a
-// spurious auto stapled on. The SK RadarControls index signature has no slot for non-numeric values, so
-// the accumulator is widened and the final cast bridges to the API type.
-function mapControls(controls: Record<string, unknown>): radar.RadarControls {
-  const out: Record<string, radar.RadarControlValue | { value: unknown }> = {}
-  for (const [id, entry] of Object.entries(controls)) {
-    if (typeof entry !== 'object' || entry === null) continue
-    if (!('value' in entry)) continue
-    const value = entry.value
-    const auto = (entry as { auto?: unknown }).auto
-    if (typeof value === 'number' && typeof auto === 'boolean') out[id] = { auto, value }
-    else if (typeof value === 'number' && AUTO_CAPABLE_CONTROLS.has(id))
-      out[id] = { auto: false, value }
-    else out[id] = { value }
-  }
-  // A radar that reports no gain still gets a sane default, as before.
-  if (!('gain' in out)) out.gain = { auto: true, value: 50 }
-  return out as radar.RadarControls
-}
-
 export function createRadarProvider(
   client: MayaraClient,
   app: MayaraServerAPI
@@ -107,11 +78,12 @@ export function createRadarProvider(
           id: radarId,
           timestamp: new Date().toISOString(),
           status: status as radar.RadarStatus,
-          // Normalise mayara's controls the way the discovery list used to
-          // (auto flags on gain/sea, gain default) — now that the lean
-          // RadarInfo carries no controls, /state and /controls are where
-          // clients read them.
-          controls: mapControls(controls)
+          // Forward mayara's controls verbatim. mayara already reports each
+          // control the way the Radar API expects — auto-capable controls
+          // (gain/sea/…) always carry a boolean `auto`, enum/list controls carry
+          // their label string — so no normalisation is needed here, and /state
+          // and /controls stay byte-identical to mayara's own responses.
+          controls: controls as unknown as radar.RadarControls
         }
       } catch (err) {
         debug(`getState error for ${radarId}: ${err instanceof Error ? err.message : String(err)}`)

--- a/test/mayara-client.test.ts
+++ b/test/mayara-client.test.ts
@@ -81,6 +81,15 @@ describe('MayaraClient', () => {
     )
   })
 
+  it('requests the state stream with subscribe=none so it never gets nav/AIS', () => {
+    const client = new MayaraClient({ host: '192.168.1.10', port: 6502 })
+    // The forwarder opts out of own-ship data (Signal K default `self` streams
+    // navigation.*) and subscribes only to radars.*/notifications.* itself.
+    expect(client.getStateStreamUrl()).toBe(
+      'ws://192.168.1.10:6502/signalk/v1/stream?subscribe=none'
+    )
+  })
+
   it('uses /targets/acquire for target acquisition', async () => {
     serverPort = await createTestServer((req, res) => {
       expect(req.method).toBe('POST')

--- a/test/mayara-client.test.ts
+++ b/test/mayara-client.test.ts
@@ -35,6 +35,24 @@ describe('MayaraClient', () => {
     expect(result).toEqual({ 'radar-0': { name: 'Test', brand: 'Furuno' } })
   })
 
+  it('unwraps the { version, radars } envelope so callers key by radar id', async () => {
+    serverPort = await createTestServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(
+        JSON.stringify({
+          version: '3.4.0',
+          radars: { 'radar-0': { name: 'Test', brand: 'Furuno' } }
+        })
+      )
+    })
+
+    const client = new MayaraClient({ host: 'localhost', port: serverPort })
+    const result = await client.getRadars()
+    // Bare map — not the envelope — so Object.keys yields ids, not version/radars.
+    expect(Object.keys(result)).toEqual(['radar-0'])
+    expect(result).toEqual({ 'radar-0': { name: 'Test', brand: 'Furuno' } })
+  })
+
   it('makes PUT requests with body', async () => {
     let receivedBody = ''
     serverPort = await createTestServer((req, res) => {

--- a/test/radar-provider.test.ts
+++ b/test/radar-provider.test.ts
@@ -91,7 +91,11 @@ describe('createRadarProvider', () => {
     }
   })
 
-  it('getState forwards the full normalized control set', async () => {
+  it('getState forwards mayara controls verbatim', async () => {
+    // mayara already reports controls in the shape the Radar API expects —
+    // auto-capable controls carry a boolean `auto`, enum/list controls carry
+    // their label string, on/off controls carry a boolean — so the provider
+    // forwards them unchanged (no normalisation on this side).
     const client = createMockClient({
       getControls: vi.fn().mockResolvedValue({
         power: { value: 2 },
@@ -99,10 +103,8 @@ describe('createRadarProvider', () => {
         gain: { auto: false, value: 50 },
         sea: { auto: true, value: 30 },
         rain: { value: 10 },
-        // mayara serves enum/list controls as their label string, not a number.
         targetTrails: { value: 'Medium' },
         mode: { value: 'dopplerNormal' },
-        // and on/off controls as booleans.
         interferenceRejection: { value: true }
       })
     })
@@ -115,50 +117,9 @@ describe('createRadarProvider', () => {
       expect(state.controls.gain).toEqual({ auto: false, value: 50 })
       expect(state.controls.sea).toEqual({ auto: true, value: 30 })
       expect(state.controls.rain).toEqual({ value: 10 })
-      // Non-numeric controls pass through verbatim instead of being dropped.
       expect(state.controls.targetTrails).toEqual({ value: 'Medium' })
       expect(state.controls.mode).toEqual({ value: 'dopplerNormal' })
       expect(state.controls.interferenceRejection).toEqual({ value: true })
-    }
-  })
-
-  it('getState does not staple auto onto a string-valued auto-capable control', async () => {
-    const client = createMockClient({
-      getControls: vi.fn().mockResolvedValue({
-        power: { value: 2 },
-        gain: { value: 40 },
-        // A radar that reports sea as an enum ("Off"/"Harbour"/...) rather than a level:
-        // it must forward as-is, never gain a spurious { auto: false }.
-        sea: { value: 'Harbour' }
-      })
-    })
-    const provider = createRadarProvider(client, createMockApp())
-
-    const state = await provider.getState('radar-0')
-    expect(state).not.toBeNull()
-    if (state) {
-      expect(state.controls.gain).toEqual({ auto: false, value: 40 })
-      expect(state.controls.sea).toEqual({ value: 'Harbour' })
-    }
-  })
-
-  it('getState defaults auto on gain and sea when mayara omits it', async () => {
-    const client = createMockClient({
-      getControls: vi.fn().mockResolvedValue({
-        power: { value: 2 },
-        gain: { value: 40 },
-        sea: { value: 20 },
-        rain: { value: 10 }
-      })
-    })
-    const provider = createRadarProvider(client, createMockApp())
-
-    const state = await provider.getState('radar-0')
-    expect(state).not.toBeNull()
-    if (state) {
-      expect(state.controls.gain).toEqual({ auto: false, value: 40 })
-      expect(state.controls.sea).toEqual({ auto: false, value: 20 })
-      expect(state.controls.rain).toEqual({ value: 10 })
     }
   })
 

--- a/test/radar-provider.test.ts
+++ b/test/radar-provider.test.ts
@@ -6,7 +6,12 @@ import { MayaraServerAPI } from '../src/types'
 function createMockClient(overrides: Partial<MayaraClient> = {}): MayaraClient {
   return {
     getRadars: vi.fn().mockResolvedValue({
-      'radar-0': { brand: 'Furuno', model: 'DRS4D-NXT', name: 'DRS4D-NXT 6424' },
+      'radar-0': {
+        brand: 'Furuno',
+        model: 'DRS4D-NXT',
+        name: 'DRS4D-NXT 6424',
+        radarIpAddress: '10.0.0.5'
+      },
       'radar-1': { brand: 'Navico', model: 'HALO', name: 'HALO 034A' }
     }),
     getCapabilities: vi.fn().mockResolvedValue({
@@ -66,36 +71,28 @@ describe('createRadarProvider', () => {
     expect(ids).toEqual([])
   })
 
-  it('getRadarInfo builds RadarInfo from controls and capabilities', async () => {
+  it('getRadarInfo returns the lean discovery object (no live state)', async () => {
     const client = createMockClient()
     const provider = createRadarProvider(client, createMockApp())
 
     const info = await provider.getRadarInfo('radar-0')
     expect(info).not.toBeNull()
     if (info) {
-      expect(info.id).toBe('radar-0')
       expect(info.name).toBe('DRS4D-NXT 6424')
       expect(info.brand).toBe('Furuno')
-      expect(info.status).toBe('transmit')
-      expect(info.spokesPerRevolution).toBe(8192)
-      expect(info.range).toBe(3000)
+      expect(info.model).toBe('DRS4D-NXT')
+      expect(info.radarIpAddress).toBe('10.0.0.5')
+      // spokeDataUrl/streamUrl omitted so clients use signalk-server's own
+      // endpoints; live state (status/controls) lives on getState, not here.
+      expect(info.spokeDataUrl).toBeUndefined()
+      expect(info.streamUrl).toBeUndefined()
+      expect('status' in info).toBe(false)
+      expect('controls' in info).toBe(false)
     }
   })
 
-  it('getRadarInfo forwards the legend and the full control set', async () => {
+  it('getState forwards the full normalized control set', async () => {
     const client = createMockClient({
-      getCapabilities: vi.fn().mockResolvedValue({
-        spokesPerRevolution: 2048,
-        maxSpokeLength: 1024,
-        legend: {
-          pixels: [
-            { color: '#00000000', type: 'normal' },
-            { color: '#0000ffff', type: 'normal' },
-            { color: '#ff0000ff', type: 'normal' },
-            { color: '#ff00ffff', type: 'dopplerApproaching' }
-          ]
-        }
-      }),
       getControls: vi.fn().mockResolvedValue({
         power: { value: 2 },
         range: { value: 3000 },
@@ -111,26 +108,21 @@ describe('createRadarProvider', () => {
     })
     const provider = createRadarProvider(client, createMockApp())
 
-    const info = await provider.getRadarInfo('radar-0')
-    expect(info).not.toBeNull()
-    if (info) {
-      expect(info.legend).toEqual([
-        { color: '#00000000', label: 'normal', minValue: 0, maxValue: 0 },
-        { color: '#0000ffff', label: 'normal', minValue: 1, maxValue: 1 },
-        { color: '#ff0000ff', label: 'normal', minValue: 2, maxValue: 2 },
-        { color: '#ff00ffff', label: 'dopplerApproaching', minValue: 3, maxValue: 3 }
-      ])
-      expect(info.controls.gain).toEqual({ auto: false, value: 50 })
-      expect(info.controls.sea).toEqual({ auto: true, value: 30 })
-      expect(info.controls.rain).toEqual({ value: 10 })
+    const state = await provider.getState('radar-0')
+    expect(state).not.toBeNull()
+    if (state) {
+      expect(state.status).toBe('transmit')
+      expect(state.controls.gain).toEqual({ auto: false, value: 50 })
+      expect(state.controls.sea).toEqual({ auto: true, value: 30 })
+      expect(state.controls.rain).toEqual({ value: 10 })
       // Non-numeric controls pass through verbatim instead of being dropped.
-      expect(info.controls.targetTrails).toEqual({ value: 'Medium' })
-      expect(info.controls.mode).toEqual({ value: 'dopplerNormal' })
-      expect(info.controls.interferenceRejection).toEqual({ value: true })
+      expect(state.controls.targetTrails).toEqual({ value: 'Medium' })
+      expect(state.controls.mode).toEqual({ value: 'dopplerNormal' })
+      expect(state.controls.interferenceRejection).toEqual({ value: true })
     }
   })
 
-  it('getRadarInfo does not staple auto onto a string-valued auto-capable control', async () => {
+  it('getState does not staple auto onto a string-valued auto-capable control', async () => {
     const client = createMockClient({
       getControls: vi.fn().mockResolvedValue({
         power: { value: 2 },
@@ -142,15 +134,15 @@ describe('createRadarProvider', () => {
     })
     const provider = createRadarProvider(client, createMockApp())
 
-    const info = await provider.getRadarInfo('radar-0')
-    expect(info).not.toBeNull()
-    if (info) {
-      expect(info.controls.gain).toEqual({ auto: false, value: 40 })
-      expect(info.controls.sea).toEqual({ value: 'Harbour' })
+    const state = await provider.getState('radar-0')
+    expect(state).not.toBeNull()
+    if (state) {
+      expect(state.controls.gain).toEqual({ auto: false, value: 40 })
+      expect(state.controls.sea).toEqual({ value: 'Harbour' })
     }
   })
 
-  it('getRadarInfo defaults auto on gain and sea when mayara omits it', async () => {
+  it('getState defaults auto on gain and sea when mayara omits it', async () => {
     const client = createMockClient({
       getControls: vi.fn().mockResolvedValue({
         power: { value: 2 },
@@ -161,12 +153,12 @@ describe('createRadarProvider', () => {
     })
     const provider = createRadarProvider(client, createMockApp())
 
-    const info = await provider.getRadarInfo('radar-0')
-    expect(info).not.toBeNull()
-    if (info) {
-      expect(info.controls.gain).toEqual({ auto: false, value: 40 })
-      expect(info.controls.sea).toEqual({ auto: false, value: 20 })
-      expect(info.controls.rain).toEqual({ value: 10 })
+    const state = await provider.getState('radar-0')
+    expect(state).not.toBeNull()
+    if (state) {
+      expect(state.controls.gain).toEqual({ auto: false, value: 40 })
+      expect(state.controls.sea).toEqual({ auto: false, value: 20 })
+      expect(state.controls.rain).toEqual({ value: 10 })
     }
   })
 


### PR DESCRIPTION
## Summary

Part of the coordinated **v3.4.0 Radar API** convergence (with [mayara-server] and [signalk-server]). The plugin bridges mayara into Signal K so a client sees the same Radar API either way.

- **Lean provider**: `getRadarInfo` returns the lean `RadarInfo`; live state via `getState`/`getCapabilities`.
- **Control bridge over the standard Signal K v1 stream**: republish mayara's `radars.*` deltas (state out) and register PUT handlers for `radars.<id>.controls.*` (control in). Connect with `?subscribe=none` so the forwarder never re-imports nav/AIS (which mayara only has because it got them from Signal K).
- **Handle mayara's `{ version, radars }` envelope** in both the client and the GUI proxy.
- **Forward mayara's controls verbatim** (mayara now guarantees `auto` on auto-capable controls).
- **Serve the mayara GUI pointed at the local Signal K server (`:3000`)** — proving the GUI, and any client, works identically direct or via Signal K.

## Tested

- `npm run build:all` — lint clean, build clean, 138 tests pass.
- Live on the boat: the mayara GUI, served by the plugin, renders spokes + controls driven entirely by the Signal K server (`:3000`).

[mayara-server]: https://github.com/MarineYachtRadar/mayara-server/pull/467
[signalk-server]: https://github.com/SignalK/signalk-server/pull/2859



## Dependency note

The Radar API v3.4.0 types are currently published only as a prerelease,
`@signalk/server-api@2.31.0-beta.1` (npm `latest` is still 2.30.0). npm semver
excludes prereleases from caret ranges, so `^2.31.0` does not match it and
installs failed with `ETARGET` — which is what took CI down here. The range now
names the prerelease explicitly.

`^2.31.0-beta.1` still accepts the final `2.31.0` and later 2.x, so this needs no
follow-up revert once the release lands. `engines.signalk` stays at `>=2.31.0`:
that is the version a user actually needs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Implements Radar API v3.4.0 integration by returning lean `getRadarInfo` discovery data and forwarding live radar state via `getState` (including controls) with a computed `status`.
- Unwraps Mayara’s `{ version, radars }` response envelope and forwards radar control values verbatim through Signal K.
- Adds per-radar Signal K v1 stream bridging for radar state deltas and registers idempotent Signal K PUT handlers that relay control updates back to Mayara.
- Proxies GUI/assets by routing `/signalk/...` requests to the local Signal K loopback and all other traffic to the configured Mayara base URL; rewrites radar `streamUrl`/`spokeDataUrl` to handle both envelope and bare-map radar list shapes.
- Expands notification forwarding to support configurable websocket subscriptions and republishing by `pathPrefixes`.
- Documents Radar API divergences and a convergence plan between `mayara-server`, `signalk-server`, and the plugin, clarifying the separate roles of spoke data vs Signal K control deltas.
- Updates compatibility requirements to Signal K Server `>= 2.31.0` and bumps `@signalk/server-api` accordingly, with tests covering the envelope unwrapping, `subscribe=none` stream URL behavior, and the lean radar discovery/state forwarding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
