### PR TITLE
chore(release): 1.5.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "1.4.4",
+  "version": "1.5.0-beta.1",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Releases `1.5.0-beta.1`.

**Minor**, not patch: the six PRs since v1.4.4 change the feature surface and the compatibility requirements, not just behaviour — the v3.4.0 Radar API convergence, CJS→ESM, webpack→Vite, the config panel to strict TypeScript, http-proxy-middleware v4, and TypeBox 1.x. The `engines` floors moved with them (`node >=22.15.0`, `signalk >=2.31.0`).

**Beta**, because the runtime this targets is not published yet. `signalk-server@2.30.0` — the current `latest` — has no radar API at all (no `dist/api/radar/`, no `radarApi` on the app object), so `app.radarApi.register()` cannot succeed there. The plugin degrades to a plugin error rather than taking the server down, but it will not function. `@signalk/server-api` is likewise still `2.30.0` on `latest` with `2.31.0-beta.1` on `beta`.

Tagging `v1.5.0-beta.1` publishes under the `beta` dist-tag and marks the GitHub release as a prerelease, so `latest` stays on 1.4.4 for existing users. Installing it is opt-in via `@beta`.

Shipping in this release:

- #90 — v3.4.0 Radar API (lean `RadarInfo`, `{version, radars}` envelope, control bridge over the standard Signal K stream)
- #91 — ESM plugin, webpack replaced by Vite + Module Federation
- #88 — http-proxy-middleware v4 (unblocked by the ESM move)
- #92 — config panel to strict TypeScript; also fixes keyboard-inaccessible controls, missing label associations, and a port field that silently saved `0`
- #93 — TypeBox 1.x
- #94 — full-stack e2e harness

## Tested

- `npm run build:all` — lint, tsc, panel typecheck, Vite build, 138 tests pass.
- `npm run format:check` — clean.
- `npm pack --dry-run` — 53 files, correct version, federation assets present.
- `npm run test:e2e` — 19/19 against a real signalk-server, real mayara-server and a real Furuno DRS4D-NXT.
- Confirmed `publish.yml` routes a `-beta.` tag to `--tag beta`, so this cannot land on `latest`.
