### PR TITLE
fix(container): raise the mayara memory cap from 512m to 1g

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,14 @@ The plugin sets sensible default resource caps so a runaway container can't take
 | Setting      | Default | Why                                                                   |
 | ------------ | ------- | --------------------------------------------------------------------- |
 | `cpus`       | `2`     | Mayara processing peaks ≈ 1 core; headroom for spikes and multi-radar |
-| `memory`     | `512m`  | Hard memory cap, OOM-killed if exceeded                               |
-| `memorySwap` | `512m`  | = memory → swap disabled (recommended on Pi/eMMC)                     |
+| `memory`     | `1g`    | Hard memory cap, OOM-killed if exceeded                               |
+| `memorySwap` | `1g`    | = memory → swap disabled (recommended on Pi/eMMC)                     |
 | `pidsLimit`  | `200`   | Bounds runaway thread leaks                                           |
+
+A dual-range radar with ARPA active sits around 380 MB steady-state, so the previous
+512 MB cap left almost no headroom: the container spent its time in memory reclaim
+rather than being OOM-killed, which looks like a sluggish radar picture rather than
+a crash. 1 GB restores headroom.
 
 Tested on a Pi 5 8GB with a Garmin xHD2 at 24 NM range. If your setup needs different limits (e.g. multiple radars, larger range, weaker hardware), override per-field via signalk-container's plugin config under **Per-container resource overrides**:
 

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -26,10 +26,15 @@ const GUI_PROXY_PATH = `/plugins/${PLUGIN_ID}/gui`;
  *
  *   signalk-container/doc/plugin-developer-guide.md §"Resource Limits"
  */
+// 1g, not 512m: a dual-range radar with ARPA running sits around 380 MB
+// steady-state — ~75% of the old cap — which leaves no headroom for the blob
+// detector's per-revolution allocations and pushes the runtime into constant
+// reclaim. That shows up to the operator as a sluggish picture rather than as
+// an OOM kill, so it is easy to misread as the plugin being slow.
 const DEFAULT_RESOURCES = {
     cpus: 2,
-    memory: '512m',
-    memorySwap: '512m', // = memory → swap disabled (recommended on Pi/eMMC)
+    memory: '1g',
+    memorySwap: '1g', // = memory → swap disabled (recommended on Pi/eMMC)
     pidsLimit: 200
 };
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,10 +50,15 @@ const GUI_PROXY_PATH = `/plugins/${PLUGIN_ID}/gui`
  *
  *   signalk-container/doc/plugin-developer-guide.md §"Resource Limits"
  */
+// 1g, not 512m: a dual-range radar with ARPA running sits around 380 MB
+// steady-state — ~75% of the old cap — which leaves no headroom for the blob
+// detector's per-revolution allocations and pushes the runtime into constant
+// reclaim. That shows up to the operator as a sluggish picture rather than as
+// an OOM kill, so it is easy to misread as the plugin being slow.
 const DEFAULT_RESOURCES: ContainerResourceLimits = {
   cpus: 2,
-  memory: '512m',
-  memorySwap: '512m', // = memory → swap disabled (recommended on Pi/eMMC)
+  memory: '1g',
+  memorySwap: '1g', // = memory → swap disabled (recommended on Pi/eMMC)
   pidsLimit: 200
 }
 

--- a/test/container-integration.test.ts
+++ b/test/container-integration.test.ts
@@ -422,8 +422,8 @@ describe('mayara-server-signalk-plugin container integration', () => {
       const { config } = containers._calls.ensureRunning[0]
       expect(config.resources).toEqual({
         cpus: 2,
-        memory: '512m',
-        memorySwap: '512m',
+        memory: '1g',
+        memorySwap: '1g',
         pidsLimit: 200
       })
       await plugin.stop()
@@ -692,8 +692,8 @@ describe('mayara-server-signalk-plugin container integration', () => {
       // Resources still applied on update
       expect(containers._calls.ensureRunning[0].config.resources).toEqual({
         cpus: 2,
-        memory: '512m',
-        memorySwap: '512m',
+        memory: '1g',
+        memorySwap: '1g',
         pidsLimit: 200
       })
       await plugin.stop()


### PR DESCRIPTION
## Summary

Raises the mayara container's memory cap from `512m` to `1g`.

Measured on the boat with a dual-range Furuno DRS4D-NXT: the container sits at **~384 MB steady-state** with ARPA running — about **72% of the old 512 MB cap** — which leaves no headroom for the blob detector's per-revolution allocations.

The failure mode is why this was easy to misread. It does **not** OOM-kill, so there is no crash and nothing in the logs. The runtime instead spends its time in memory reclaim, and the operator sees a sluggish radar picture and reasonably concludes the plugin is slow.

Nothing in the Signal K path was actually slow. Every proxied request measured **2–9 ms** and returned 200 while the symptom was being reported.

Also updates the README resource table (per the AGENTS.md rule that defaults and the table stay in step) and the two tests that pinned the old value.

## Tested

- `npm run build:all` — 138 tests pass.
- `npm run format:check` — clean.
- Confirmed against the live container: `podman inspect` reports the 512 MB limit and `podman stats` shows 384 MB / 71.6% sustained across repeated samples.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Raises the mayara container memory and swap limits from `512m` to `1g`.
- Documents the increased limits and explains the memory-reclaim issue during dual-range ARPA usage.
- Updates container integration tests to expect the new limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->