### PR TITLE
chore(deps): add signalk-container-helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "http-proxy-middleware": "^4.2.0",
+    "signalk-container-helper": "^0.3.0",
     "typebox": "^1.3.11",
     "ws": "^8.14.0"
   },


### PR DESCRIPTION
## Summary

Adds `signalk-container-helper` as a dependency. Groundwork only — no behaviour change.

This plugin hand-rolls its container lifecycle: waiting for the manager, validating tags, reconciling via `ensureRunning`, registering for update detection, and mounting `/api/update/check` + `/api/update/apply`. The library packages exactly those patterns, and its README lists this plugin as one of the archetypes they were extracted from — `ManagedContainer` is described as "the signalk-backup / mayara archetype" — so the fit is close by construction.

**No `engines` change.** 0.3.0 lowered the library's floor to Node `>=22`, matching what this plugin already declares. An earlier revision of this branch bumped us to `>=24` against 0.2.1 and dropped Node 22 from the CI matrix; that was reverted once 0.3.0 landed, since taking a compatibility break you no longer need is pure cost. `@types/node`, the dependabot pin and the README are unchanged as a result.

The migration itself lands separately: the server-side move onto `ManagedContainer` will touch four `ensureRunning` call sites inside a 1,393-line `src/index.ts` and will churn several regression tests in `container-integration.test.ts`, so it deserves its own reviewable diff. The config panel is a third step — the library's `ui` entrypoint ships `splitVersions` and `formatUpdateMessage`, which are literally this plugin's function names.

## Tested

- `npm run build:all` — 138 tests pass on the Node 22 floor.
- `npm run format:check` — clean.
- Probed the library directly to confirm the migration is feasible before committing to it. The Signal K device-token flow is the one place this plugin's lifecycle is more complex than the archetype: it recreates the container mid-flight with `MAYARA_SIGNALK_TOKEN` once the operator approves the access request. Calling `start()` again after mutating what `buildConfig` closes over produces a second `ensureRunning` carrying the new env (`{}` → `{MAYARA_SIGNALK_TOKEN: "…"}`), so it maps onto repeated `start()` with no special API. Re-verified against 0.3.0 rather than assuming the API was stable across the version change.

Plan and open questions: `~/dev/plans/mayara-server-signalk-plugin/container-helper-refactor.md`.
