### PR TITLE
refactor(container): use signalk-container-helper for manager access and types

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,6 +28,17 @@ export default tseslint.config(
     }
   },
   {
+    // Test doubles are plain `vi.fn()` stubs on object literals, so referencing
+    // one to assert on it (`vi.mocked(mock.whenReady)`) can never lose a `this`
+    // binding — the rule's real target is methods on classes/prototypes. It
+    // only started firing once signalk-container-helper's typed interfaces
+    // replaced the loose local mirror.
+    files: ['test/**/*.ts'],
+    rules: {
+      '@typescript-eslint/unbound-method': 'off'
+    }
+  },
+  {
     // The config panel is a browser bundle with its own tsconfig (DOM libs +
     // JSX, deliberately kept out of the Node compile), so the type-aware
     // parser needs to be pointed at that project for these files rather than

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,5 +1,6 @@
 import { Server as NetServer } from 'net';
 import { createProxyMiddleware, fixRequestBody, responseInterceptor } from 'http-proxy-middleware';
+import { getContainerManager as helperGetContainerManager, waitForContainerManager, isValidImageTag } from 'signalk-container-helper';
 import { MayaraClient } from './mayara-client.js';
 import { rewriteGuiProxyPath } from './gui-proxy-path.js';
 import { createRadarProvider } from './radar-provider.js';
@@ -10,7 +11,6 @@ import { awaitApproval, beginTokenRequest, deleteCachedToken, readCachedToken, r
 const MAYARA_IMAGE = 'ghcr.io/marineyachtradar/mayara-server';
 const CONTAINER_NAME = 'mayara-server';
 const PLUGIN_ID = 'mayara-server-signalk-plugin';
-const SAFE_TAG = /^[a-zA-Z0-9._-]+$/;
 // Same-origin path the SK server forwards to mayara-server's :6502.
 // Keeps the browser on the SK port (3000 / 443), so HTTPS works and
 // only one firewall port needs to be open.
@@ -41,9 +41,13 @@ const DEFAULT_RESOURCES = {
  * Typed accessor for the cross-plugin container manager API. Returns
  * undefined if signalk-container has not finished start() yet, or if
  * the user has it disabled. Callers should always handle undefined.
+ *
+ * Delegates to signalk-container-helper so the "where does the manager live"
+ * knowledge sits in one shared place; the local cast keeps our own typed
+ * `ContainerManagerApi` mirror (src/types.ts) as the contract callers see.
  */
 function getContainerManager() {
-    return globalThis.__signalk_containerManager;
+    return helperGetContainerManager();
 }
 export default function (app) {
     let client = null;
@@ -408,7 +412,7 @@ export default function (app) {
                 const tag = (typeof body.tag === 'string' ? body.tag : undefined) ??
                     currentSettings?.mayaraVersion ??
                     'latest';
-                if (!SAFE_TAG.test(tag)) {
+                if (!isValidImageTag(tag)) {
                     res.status(400).json({ error: 'Invalid tag format' });
                     return;
                 }
@@ -513,7 +517,7 @@ export default function (app) {
                 if (relSettled.status === 'fulfilled' && relSettled.value.ok) {
                     const data = (await relSettled.value.json());
                     releases.push(...data
-                        .filter((r) => !r.draft && SAFE_TAG.test(r.tag_name))
+                        .filter((r) => !r.draft && isValidImageTag(r.tag_name))
                         .map((r) => ({ tag: r.tag_name, prerelease: r.prerelease })));
                 }
                 const prImages = [];
@@ -522,7 +526,7 @@ export default function (app) {
                     prImages.push(...pulls
                         .filter((p) => p.labels.some((l) => l.name === 'build-image'))
                         .map((p) => ({ tag: `pr${p.number}`, pr: p.number, title: p.title }))
-                        .filter((p) => SAFE_TAG.test(p.tag)));
+                        .filter((p) => isValidImageTag(p.tag)));
                 }
                 const classify = (settled) => {
                     if (settled.status !== 'fulfilled')
@@ -854,41 +858,26 @@ export default function (app) {
         }
         app.debug('Signal K token recovery gave up after repeated failures; restart the plugin to retry');
     }
-    /**
-     * Wait up to `timeoutMs` for signalk-container to be both loaded
-     * (cross-plugin global populated) and finished with runtime detection.
-     * Returns the container manager handle, or undefined if either phase
-     * timed out or detection failed. Caller sets a plugin error on
-     * undefined.
-     */
-    async function waitForContainerManager(timeoutMs = 30000) {
-        const deadline = Date.now() + timeoutMs;
-        // Phase 1: poll for the cross-plugin global. signalk-container's
-        // start() may not have run yet on a fresh SK boot.
-        let containers = getContainerManager();
-        while (!containers && Date.now() < deadline) {
-            app.setPluginStatus('Waiting for signalk-container plugin to load...');
-            await new Promise((resolve) => setTimeout(resolve, 500));
-            containers = getContainerManager();
-        }
-        if (!containers)
-            return undefined;
-        // Phase 2: await whenReady() with a remaining-time cap. whenReady()
-        // resolves on success OR failure of runtime detection, so re-check
-        // getRuntime() afterwards.
-        app.setPluginStatus('Waiting for container runtime detection...');
-        const remaining = Math.max(0, deadline - Date.now());
-        await Promise.race([
-            containers.whenReady(),
-            new Promise((resolve) => setTimeout(resolve, remaining))
-        ]);
-        return containers.getRuntime() ? containers : undefined;
-    }
     async function startManagedContainer(settings) {
-        const containers = await waitForContainerManager();
+        // Two-phase wait (global appears → runtime detection settles), from
+        // signalk-container-helper. Unlike the hand-rolled version this replaced,
+        // it distinguishes "signalk-container absent" from "present but no usable
+        // podman/docker", which are different operator problems.
+        const { manager: containers, runtime } = await waitForContainerManager({
+            timeoutMs: 30000,
+            onWaiting: (phase) => {
+                app.setPluginStatus(phase === 'manager'
+                    ? 'Waiting for signalk-container plugin to load...'
+                    : 'Waiting for container runtime detection...');
+            }
+        });
         if (!containers) {
             app.setPluginError('signalk-container plugin required for managed mode. Install it or set managedContainer=false.');
             throw new Error('Container manager not available');
+        }
+        if (!runtime) {
+            app.setPluginError('signalk-container found no usable container runtime (podman/docker). Check its status.');
+            throw new Error('No container runtime detected');
         }
         app.debug('Container runtime ready, starting mayara-server');
         app.setPluginStatus('Starting mayara-server container...');

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,11 @@ import {
   responseInterceptor,
   type RequestHandler
 } from 'http-proxy-middleware'
+import {
+  getContainerManager as helperGetContainerManager,
+  waitForContainerManager,
+  isValidImageTag
+} from 'signalk-container-helper'
 import { MayaraClient } from './mayara-client.js'
 import { rewriteGuiProxyPath } from './gui-proxy-path.js'
 import { createRadarProvider } from './radar-provider.js'
@@ -33,7 +38,6 @@ import {
 const MAYARA_IMAGE = 'ghcr.io/marineyachtradar/mayara-server'
 const CONTAINER_NAME = 'mayara-server'
 const PLUGIN_ID = 'mayara-server-signalk-plugin'
-const SAFE_TAG = /^[a-zA-Z0-9._-]+$/
 // Same-origin path the SK server forwards to mayara-server's :6502.
 // Keeps the browser on the SK port (3000 / 443), so HTTPS works and
 // only one firewall port needs to be open.
@@ -66,9 +70,13 @@ const DEFAULT_RESOURCES: ContainerResourceLimits = {
  * Typed accessor for the cross-plugin container manager API. Returns
  * undefined if signalk-container has not finished start() yet, or if
  * the user has it disabled. Callers should always handle undefined.
+ *
+ * Delegates to signalk-container-helper so the "where does the manager live"
+ * knowledge sits in one shared place; the local cast keeps our own typed
+ * `ContainerManagerApi` mirror (src/types.ts) as the contract callers see.
  */
 function getContainerManager(): ContainerManagerApi | undefined {
-  return globalThis.__signalk_containerManager
+  return helperGetContainerManager()
 }
 
 export default function (app: MayaraServerAPI): Plugin {
@@ -457,7 +465,7 @@ export default function (app: MayaraServerAPI): Plugin {
           (typeof body.tag === 'string' ? body.tag : undefined) ??
           currentSettings?.mayaraVersion ??
           'latest'
-        if (!SAFE_TAG.test(tag)) {
+        if (!isValidImageTag(tag)) {
           res.status(400).json({ error: 'Invalid tag format' })
           return
         }
@@ -576,7 +584,7 @@ export default function (app: MayaraServerAPI): Plugin {
           }[]
           releases.push(
             ...data
-              .filter((r) => !r.draft && SAFE_TAG.test(r.tag_name))
+              .filter((r) => !r.draft && isValidImageTag(r.tag_name))
               .map((r) => ({ tag: r.tag_name, prerelease: r.prerelease }))
           )
         }
@@ -592,7 +600,7 @@ export default function (app: MayaraServerAPI): Plugin {
             ...pulls
               .filter((p) => p.labels.some((l) => l.name === 'build-image'))
               .map((p) => ({ tag: `pr${p.number}`, pr: p.number, title: p.title }))
-              .filter((p) => SAFE_TAG.test(p.tag))
+              .filter((p) => isValidImageTag(p.tag))
           )
         }
 
@@ -1009,47 +1017,32 @@ export default function (app: MayaraServerAPI): Plugin {
     )
   }
 
-  /**
-   * Wait up to `timeoutMs` for signalk-container to be both loaded
-   * (cross-plugin global populated) and finished with runtime detection.
-   * Returns the container manager handle, or undefined if either phase
-   * timed out or detection failed. Caller sets a plugin error on
-   * undefined.
-   */
-  async function waitForContainerManager(
-    timeoutMs = 30000
-  ): Promise<ContainerManagerApi | undefined> {
-    const deadline = Date.now() + timeoutMs
-
-    // Phase 1: poll for the cross-plugin global. signalk-container's
-    // start() may not have run yet on a fresh SK boot.
-    let containers = getContainerManager()
-    while (!containers && Date.now() < deadline) {
-      app.setPluginStatus('Waiting for signalk-container plugin to load...')
-      await new Promise<void>((resolve) => setTimeout(resolve, 500))
-      containers = getContainerManager()
-    }
-    if (!containers) return undefined
-
-    // Phase 2: await whenReady() with a remaining-time cap. whenReady()
-    // resolves on success OR failure of runtime detection, so re-check
-    // getRuntime() afterwards.
-    app.setPluginStatus('Waiting for container runtime detection...')
-    const remaining = Math.max(0, deadline - Date.now())
-    await Promise.race([
-      containers.whenReady(),
-      new Promise<void>((resolve) => setTimeout(resolve, remaining))
-    ])
-    return containers.getRuntime() ? containers : undefined
-  }
-
   async function startManagedContainer(settings: Partial<Config>): Promise<void> {
-    const containers = await waitForContainerManager()
+    // Two-phase wait (global appears → runtime detection settles), from
+    // signalk-container-helper. Unlike the hand-rolled version this replaced,
+    // it distinguishes "signalk-container absent" from "present but no usable
+    // podman/docker", which are different operator problems.
+    const { manager: containers, runtime } = await waitForContainerManager({
+      timeoutMs: 30000,
+      onWaiting: (phase) => {
+        app.setPluginStatus(
+          phase === 'manager'
+            ? 'Waiting for signalk-container plugin to load...'
+            : 'Waiting for container runtime detection...'
+        )
+      }
+    })
     if (!containers) {
       app.setPluginError(
         'signalk-container plugin required for managed mode. Install it or set managedContainer=false.'
       )
       throw new Error('Container manager not available')
+    }
+    if (!runtime) {
+      app.setPluginError(
+        'signalk-container found no usable container runtime (podman/docker). Check its status.'
+      )
+      throw new Error('No container runtime detected')
     }
 
     app.debug('Container runtime ready, starting mayara-server')

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,208 +9,28 @@ export interface MayaraServerAPI extends ServerAPI {
 }
 
 // =============================================================================
-// signalk-container v1.6.0 API mirror
+// signalk-container types
 // =============================================================================
 //
-// These types are intentionally hand-rolled rather than imported from the
-// signalk-container package, to keep mayara loosely coupled (only a runtime
-// `peerDependencies` declaration, no compile-time import).
+// Previously hand-mirrored here to avoid a compile-time dependency on
+// signalk-container (whose prerelease versioning breaks npm semver ranges).
+// signalk-container-helper solves that properly: it is a normal dependency
+// that re-exports the manager contract, so the mirror is gone and these types
+// can no longer drift from the real API.
 //
-// The source of truth lives in the signalk-container repository at:
-//   https://github.com/dirkwa/signalk-container
-//   - src/types.ts            — top-level container manager interfaces
-//   - src/updates/types.ts    — update detection service
-//
-// When signalk-container's API changes, mirror the relevant subset here. Only
-// the methods mayara actually uses need to be declared.
-//
-// Last synced against signalk-container: v1.6.0
-
-export type ContainerState = 'running' | 'stopped' | 'missing' | 'no-runtime'
-
-export interface ContainerRuntimeInfo {
-  runtime: 'podman' | 'docker'
-  version: string
-  isPodmanDockerShim: boolean
-}
-
-export interface ContainerResourceLimits {
-  cpus?: number | null
-  cpuShares?: number | null
-  cpusetCpus?: string | null
-  memory?: string | null
-  memorySwap?: string | null
-  memoryReservation?: string | null
-  pidsLimit?: number | null
-  oomScoreAdj?: number | null
-}
-
-export interface ContainerConfig {
-  image: string
-  tag: string
-  ports?: Record<string, string>
-  volumes?: Record<string, string>
-  env?: Record<string, string>
-  restart?: 'no' | 'unless-stopped' | 'always'
-  command?: string[]
-  networkMode?: string
-  resources?: ContainerResourceLimits
-  // signalk-container `user` field. Tells the runtime layer the
-  // image's USER directive UID/GID so it can emit the right uid-
-  // mapping flag (`--userns=keep-id:uid=X,gid=Y` on rootless podman,
-  // `--user X:Y` on docker/rootful). Default of `undefined` means
-  // signalk-container assumes inImageUid/Gid = 0, which is wrong for
-  // any non-root image like mayara (USER mayara, UID 1000).
-  user?: { inImageUid?: number; inImageGid?: number } | false
-  // signalk-container ≥1.9.0 floating-tag auto-update opt-in. When
-  // true AND `tag` classifies as floating (latest/main/edge/nightly/
-  // stable/dev/rolling/head/trunk, or bare major like v3),
-  // ensureRunning pulls on every call, compares the registry digest
-  // against the live container's image, and recreates on drift.
-  // Offline tolerance is handled inside signalk-container — pull
-  // failures classified as offline (ENOTFOUND, ENETUNREACH, etc.)
-  // are logged at debug and the cached container is left running.
-  // No-op for semver pins.
-  autoUpdateOnFloatingTag?: boolean
-}
-
-export interface ContainerInfo {
-  name: string
-  image: string
-  state: ContainerState
-}
-
-export interface UpdateResourcesResult {
-  method: 'live' | 'recreated'
-  warnings?: string[]
-}
-
-// ----- update service ------------------------------------------------------
-
-export type UpdateReason =
-  | 'newer-version'
-  | 'digest-drift'
-  | 'older-than-pinned'
-  | 'up-to-date'
-  | 'offline'
-  | 'unknown'
-  | 'error'
-
-export type UpdateTagKind = 'semver' | 'floating' | 'unknown'
-
-export interface UpdateCheckResult {
-  pluginId: string
-  containerName: string
-  runningTag: string
-  tagKind: UpdateTagKind
-  currentVersion: string | null
-  latestVersion: string | null
-  updateAvailable: boolean
-  reason: UpdateReason
-  error?: string
-  checkedAt: string
-  lastSuccessfulCheckAt: string | null
-  fromCache: boolean
-}
-
-export interface VersionSource {
-  // The actual signature uses ContainerRuntimeInfo, but mayara never
-  // constructs sources by hand — it uses the factories on `updates.sources`.
-  // Treating fetch as opaque is sufficient for the registration flow.
-  fetch: (...args: unknown[]) => Promise<unknown>
-}
-
-export interface UpdateRegistration {
-  pluginId: string
-  containerName: string
-  image: string
-  currentTag: () => string
-  versionSource: VersionSource
-  currentVersion?: () => Promise<string | null>
-  checkInterval?: string
-}
-
-export interface UpdateServiceApi {
-  register: (reg: UpdateRegistration) => void
-  unregister: (pluginId: string) => void
-  checkOne: (pluginId: string) => Promise<UpdateCheckResult>
-  checkAll: () => Promise<UpdateCheckResult[]>
-  getLastResult: (pluginId: string) => UpdateCheckResult | null
-  sources: {
-    githubReleases: (
-      repo: string,
-      options?: {
-        allowPrerelease?: boolean
-        tagPrefix?: string
-        // Optional GitHub token (Authorization: Bearer) — lifts the REST
-        // rate limit from 60 to 5000 req/hr per IP, so the update check
-        // doesn't 403/429 on a boat sharing a WAN IP.
-        token?: string
-      }
-    ) => VersionSource
-    dockerHubTags: (image: string, options?: { filter?: (tag: string) => boolean }) => VersionSource
-  }
-}
-
-// ----- top-level container manager API -------------------------------------
-
-export interface ContainerManagerApi {
-  getRuntime: () => ContainerRuntimeInfo | null
-  /**
-   * Resolves once runtime detection has settled (success OR failure).
-   * `getRuntime()` is guaranteed non-null only when this resolves AND
-   * detection succeeded — callers should re-check after the await.
-   * Available in signalk-container 1.6.0+.
-   */
-  whenReady: () => Promise<void>
-  pullImage: (image: string, onProgress?: (msg: string) => void) => Promise<void>
-  imageExists: (image: string) => Promise<boolean>
-  getImageDigest: (imageOrContainer: string) => Promise<string | null>
-  ensureRunning: (name: string, config: ContainerConfig) => Promise<void>
-  start: (name: string) => Promise<void>
-  stop: (name: string) => Promise<void>
-  remove: (name: string) => Promise<void>
-  getState: (name: string) => Promise<ContainerState>
-  listContainers: () => Promise<ContainerInfo[]>
-  updateResources: (name: string, limits: ContainerResourceLimits) => Promise<UpdateResourcesResult>
-  getResources: (name: string) => ContainerResourceLimits
-  /**
-   * Translate an arbitrary in-SK absolute path into the `(source, subPath)`
-   * pair that a managed container's bind mount can reach on the host,
-   * regardless of how SignalK itself is deployed (bare-metal, Docker
-   * with a bind, Docker with a named volume, etc.).
-   *
-   * `source` plugs straight into `ContainerConfig.volumes` as the
-   * host-side mount source; `subPath` is the path inside that mount
-   * where `absPath` lives (empty string when the source already
-   * corresponds to absPath).
-   *
-   * Returns `null` when SignalK runs inside a container and no mount
-   * covers `absPath` — the host runtime physically cannot see it.
-   * Bare-metal callers always get a result. Available in
-   * signalk-container 1.1.0+ (peer-dep floor here is 1.6.0, so always
-   * present).
-   */
-  resolveHostPath: (absPath: string) => Promise<{ source: string; subPath: string } | null>
-  updates: UpdateServiceApi
-}
-
-// =============================================================================
-// Typed global access
-// =============================================================================
-//
-// signalk-container exposes itself via `globalThis.__signalk_containerManager`
-// rather than a property on the `app` object, because Signal K passes each
-// plugin a shallow copy of `app` — properties set on it would not be visible
-// across plugins. The cross-plugin bus is the global. See:
-//
-//   signalk-container/doc/plugin-developer-guide.md
-//   §"Critical: Cross-Plugin Communication"
-//
-// This declaration gives consumer code a typed view of the global without
-// repeated `as` casts. Use `getContainerManager()` from index.ts which adds
+// The `__signalk_containerManager` global is declared by the helper — plugins
+// each receive a shallow copy of `app`, so signalk-container publishes its API
+// on globalThis instead. Use `getContainerManager()` from index.ts, which adds
 // the not-yet-loaded check.
 
-declare global {
-  var __signalk_containerManager: ContainerManagerApi | undefined
-}
+export type {
+  ContainerConfig,
+  ContainerInfo,
+  ContainerManagerApi,
+  ContainerResourceLimits,
+  ContainerRuntimeInfo,
+  ContainerState,
+  UpdateCheckResult,
+  UpdateRegistration,
+  UpdateServiceApi
+} from 'signalk-container-helper'

--- a/test/container-integration.test.ts
+++ b/test/container-integration.test.ts
@@ -497,21 +497,53 @@ describe('mayara-server-signalk-plugin container integration', () => {
       await plugin.stop()
     })
 
-    it('awaits containers.whenReady() before calling ensureRunning', async () => {
-      // signalk-container 1.6.0 exposes whenReady() as the canonical
-      // "wait for runtime detection to settle" signal. Mayara must
-      // await it before any other container API call, otherwise
-      // ensureRunning would race against runtime probing on a cold
-      // SK boot. Use vitest's invocationCallOrder to assert
-      // whenReady was invoked strictly before ensureRunning.
+    it('waits for runtime detection to settle before calling ensureRunning', async () => {
+      // The invariant: ensureRunning must never race runtime probing on a
+      // cold SK boot. signalk-container-helper enforces it by awaiting
+      // whenReady() — but only when getRuntime() is still null, since a
+      // runtime that already resolved means detection has settled and there
+      // is nothing left to wait for.
+      //
+      // This mock returns a runtime synchronously, so the fast path is
+      // expected and whenReady() is legitimately skipped. Assert the property
+      // that matters (detection settled first), not the call that used to
+      // implement it.
       const { containers, plugin } = await loadPlugin()
-      expect(containers.whenReady).toHaveBeenCalledTimes(1)
-      const whenReadyOrder = (
-        containers.whenReady as unknown as { mock: { invocationCallOrder: number[] } }
-      ).mock.invocationCallOrder[0]
-      const ensureRunningOrder = (
-        containers.ensureRunning as unknown as { mock: { invocationCallOrder: number[] } }
-      ).mock.invocationCallOrder[0]
+      expect(containers.getRuntime()).not.toBeNull()
+      expect(containers._calls.ensureRunning.length).toBe(1)
+      await plugin.stop()
+    })
+
+    it('awaits whenReady() when runtime detection has not settled yet', async () => {
+      // The slow path: getRuntime() is null until whenReady() resolves, which
+      // is the cold-boot case the fast path above cannot cover.
+      const containers = makeMockContainerManager()
+      let settled = false
+      containers.getRuntime = vi.fn(() =>
+        settled ? { runtime: 'podman' as const, version: '5.0.0', isPodmanDockerShim: false } : null
+      )
+      containers.whenReady = vi.fn(() => {
+        settled = true
+        return Promise.resolve()
+      })
+      globalThis.__signalk_containerManager = containers
+
+      const app = makeMockApp()
+      vi.resetModules()
+      const mod = (await import('../src/index.js')) as unknown as {
+        default: (a: unknown) => LoadedPlugin['plugin']
+      }
+      const plugin = mod.default(app)
+      plugin.start({ managedContainer: true, mayaraVersion: 'latest' })
+      await vi.waitFor(() => {
+        expect(containers._calls.ensureRunning.length).toBe(1)
+      })
+
+      const whenReadyMock = vi.mocked(containers.whenReady)
+      const ensureRunningMock = vi.mocked(containers.ensureRunning)
+      expect(whenReadyMock).toHaveBeenCalledTimes(1)
+      const whenReadyOrder = whenReadyMock.mock.invocationCallOrder[0]
+      const ensureRunningOrder = ensureRunningMock.mock.invocationCallOrder[0]
       expect(whenReadyOrder).toBeLessThan(ensureRunningOrder)
       await plugin.stop()
     })


### PR DESCRIPTION
## Summary

First step of moving this plugin's container integration onto `signalk-container-helper`. Manager access and types only — the lifecycle (`start`/`stop`/update routes) follows separately.

- **`src/types.ts`: 216 lines → 37.** It hand-mirrored signalk-container's manager contract, with a comment explaining why: a compile-time dependency on signalk-container was impractical because its prerelease versioning breaks npm semver ranges. The helper solves that properly, so the mirror is deleted and those types can no longer drift from the real API.
- **`waitForContainerManager`** — the helper's version distinguishes "signalk-container absent" from "present but no usable podman/docker". Ours collapsed both into `undefined` and reported the first message, which was actively misleading in the second case. That is a small behaviour improvement, not just a swap.
- **`getContainerManager`** delegates to the helper, so "where does the manager live" is knowledge held in one place.
- **`SAFE_TAG`** → the helper's `isValidImageTag`, same validation.

Net: **155 lines removed**.

## Behavioural notes

**`whenReady()` is now skipped when `getRuntime()` already resolves.** That is correct — a resolved runtime means detection has settled and there is nothing left to await — but it broke a test that asserted the *call* rather than the invariant. The test now asserts what actually matters (detection settled before `ensureRunning`), and a **new** test covers the cold-boot path where `getRuntime()` is null and `whenReady()` genuinely is awaited. That path had no coverage before, so this is a net gain in the guard rather than a weakening of it.

**`@typescript-eslint/unbound-method` is switched off for `test/`.** Mock assertions on `vi.fn()` stubs cannot lose a `this` binding — the rule targets methods on classes and prototypes. It only started firing here because the helper's typed interfaces replaced the loose local mirror, so it is a consequence of better types rather than a new risk.

## Tested

- `npm run build:all` — 139 tests pass (up from 138: the new cold-boot test).
- `npm run format:check` — clean.
- `npm run test:e2e` — **19/19 against the real stack**: a real signalk-server with the plugin installed, a real mayara-server, and a real Furuno DRS4D-NXT. This is the check that matters for a container-integration change, since the unit tests run against a mocked manager.
- `cr review` — no findings.

## Upstream

Checked deliberately, nothing worth filing. The one divergence is `ContainerRuntimeInfo.isPodmanDockerShim`: required in signalk-container, optional in the helper. But signalk-container already marks that field `@deprecated — always false since the move to the dockerode socket client… will be removed`, so the helper being laxer is ahead of the curve rather than wrong.
