### PR TITLE
chore(release): 1.5.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "1.5.0-beta.1",
+  "version": "1.5.0-beta.2",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Releases `1.5.0-beta.2`. The point of this one is to get the memory fix onto the boat.

`1.5.0-beta.1` still carries the old **512 MB** cap — #97 merged after that beta was published, so the fix for the reported sluggishness has never actually run on hardware. Confirmed on the live system: the plugin reports `1.5.0-beta.1` and `podman inspect sk-mayara-server` reports a 512 MB limit while the container sits at ~384 MB.

Shipping since beta.1:

- **#97 — mayara memory cap 512m → 1g.** The reason for this release. A dual-range radar with ARPA running sits at ~72% of the old cap, so the runtime spends its time in memory reclaim rather than OOM-killing; the operator sees a sluggish picture and no crash in the logs.
- **#98** — adds `signalk-container-helper`.
- **#99** — manager access and types onto the helper. `src/types.ts` 216 → 37 lines; the hand-mirrored signalk-container contract is gone, so those types can no longer drift. Also a small behaviour improvement: `waitForContainerManager` now distinguishes "signalk-container absent" from "present but no usable runtime", where the old code reported the first message for both.

Still a beta for the same reason as beta.1: signalk-server 2.31.0 (which carries the v3.4.0 Radar API) is not published. Tagging `v1.5.0-beta.2` publishes under the `beta` dist-tag, so `latest` stays on 1.4.4.

## Tested

- `npm run build:all` — 139 tests pass.
- `npm run format:check` — clean.
- Confirmed the built artifact carries the fix: `plugin/index.js` emits `memory: '1g'`.
- `npm pack --dry-run` — 53 files, correct version.
- The preceding branch was verified with `npm run test:e2e` — 19/19 against a real signalk-server, real mayara-server and a real Furuno DRS4D-NXT.

## After installing on the boat

The container must be **recreated**, not just restarted, for the new limit to take effect. `ensureRunning` should handle that via config drift, but it is worth confirming:

```
podman inspect sk-mayara-server --format '{{.HostConfig.Memory}}'
```

should read `1073741824` (1 GB) rather than `536870912`. That is the check that tells us whether the original slowness is actually addressed.
