### PR TITLE
fix(radar): report unknown state instead of a false 'off' on a failed read

### DIFF
--- a/plugin/radar-provider.js
+++ b/plugin/radar-provider.js
@@ -1,3 +1,34 @@
+/**
+ * mayara's `power` enum, per the control's own `descriptions` map:
+ * 0 Off, 1 Standby, 2 Transmit, 3 Preparing, 4 Fault.
+ *
+ * `warming` is the Radar API's name for what mayara calls "Preparing" — the
+ * magnetron warm-up between standby and transmit.
+ *
+ * Fault has no Radar API equivalent. It maps to `off` because the radar is
+ * genuinely not usable, which is the closest honest answer the enum allows;
+ * the fault itself surfaces through notifications, not through this field.
+ */
+const POWER_TO_STATUS = {
+    0: 'off',
+    1: 'standby',
+    2: 'transmit',
+    3: 'warming',
+    4: 'off'
+};
+/**
+ * Map a raw mayara power value to a Radar API status, or null when there is no
+ * usable reading.
+ *
+ * Returning null matters: the previous implementation treated every value that
+ * was not 1 or 2 as `off`, so a missing control — a transiently failed fetch, a
+ * 401 from an expired session — reported the radar as confidently powered down.
+ * An operator watching a transmitting radar flip to "Off" reasonably concludes
+ * the radar died, when in fact only the read did.
+ */
+function toRadarStatus(value) {
+    return typeof value === 'number' ? (POWER_TO_STATUS[value] ?? null) : null;
+}
 export function createRadarProvider(client, app) {
     const debug = app.debug.bind(app);
     return {
@@ -58,11 +89,19 @@ export function createRadarProvider(client, app) {
             try {
                 const controls = await client.getControls(radarId);
                 const powerCtrl = controls.power;
-                const status = powerCtrl?.value === 2 ? 'transmit' : powerCtrl?.value === 1 ? 'standby' : 'off';
+                const status = toRadarStatus(powerCtrl?.value);
+                if (status === null) {
+                    // No usable power reading — the control was absent or carried a value
+                    // we do not have a mapping for. Report "no state" rather than
+                    // guessing: a null here surfaces as unknown, whereas returning a
+                    // state would assert something we cannot substantiate.
+                    debug(`getState for ${radarId}: no usable power value (${JSON.stringify(powerCtrl?.value)})`);
+                    return null;
+                }
                 return {
                     id: radarId,
                     timestamp: new Date().toISOString(),
-                    status: status,
+                    status,
                     // Forward mayara's controls verbatim. mayara already reports each
                     // control the way the Radar API expects — auto-capable controls
                     // (gain/sea/…) always carry a boolean `auto`, enum/list controls carry

--- a/src/radar-provider.ts
+++ b/src/radar-provider.ts
@@ -2,6 +2,39 @@ import { radar } from '@signalk/server-api'
 import { MayaraClient } from './mayara-client.js'
 import { MayaraServerAPI } from './types.js'
 
+/**
+ * mayara's `power` enum, per the control's own `descriptions` map:
+ * 0 Off, 1 Standby, 2 Transmit, 3 Preparing, 4 Fault.
+ *
+ * `warming` is the Radar API's name for what mayara calls "Preparing" — the
+ * magnetron warm-up between standby and transmit.
+ *
+ * Fault has no Radar API equivalent. It maps to `off` because the radar is
+ * genuinely not usable, which is the closest honest answer the enum allows;
+ * the fault itself surfaces through notifications, not through this field.
+ */
+const POWER_TO_STATUS: Record<number, radar.RadarStatus> = {
+  0: 'off',
+  1: 'standby',
+  2: 'transmit',
+  3: 'warming',
+  4: 'off'
+}
+
+/**
+ * Map a raw mayara power value to a Radar API status, or null when there is no
+ * usable reading.
+ *
+ * Returning null matters: the previous implementation treated every value that
+ * was not 1 or 2 as `off`, so a missing control — a transiently failed fetch, a
+ * 401 from an expired session — reported the radar as confidently powered down.
+ * An operator watching a transmitting radar flip to "Off" reasonably concludes
+ * the radar died, when in fact only the read did.
+ */
+function toRadarStatus(value: unknown): radar.RadarStatus | null {
+  return typeof value === 'number' ? (POWER_TO_STATUS[value] ?? null) : null
+}
+
 export function createRadarProvider(
   client: MayaraClient,
   app: MayaraServerAPI
@@ -71,13 +104,22 @@ export function createRadarProvider(
       try {
         const controls = await client.getControls(radarId)
         const powerCtrl = controls.power as Record<string, unknown> | undefined
-        const status =
-          powerCtrl?.value === 2 ? 'transmit' : powerCtrl?.value === 1 ? 'standby' : 'off'
+        const status = toRadarStatus(powerCtrl?.value)
+        if (status === null) {
+          // No usable power reading — the control was absent or carried a value
+          // we do not have a mapping for. Report "no state" rather than
+          // guessing: a null here surfaces as unknown, whereas returning a
+          // state would assert something we cannot substantiate.
+          debug(
+            `getState for ${radarId}: no usable power value (${JSON.stringify(powerCtrl?.value)})`
+          )
+          return null
+        }
 
         return {
           id: radarId,
           timestamp: new Date().toISOString(),
-          status: status as radar.RadarStatus,
+          status,
           // Forward mayara's controls verbatim. mayara already reports each
           // control the way the Radar API expects — auto-capable controls
           // (gain/sea/…) always carry a boolean `auto`, enum/list controls carry

--- a/test/radar-provider.test.ts
+++ b/test/radar-provider.test.ts
@@ -143,6 +143,46 @@ describe('createRadarProvider', () => {
     }
   })
 
+  it('getState maps every mayara power state', async () => {
+    // mayara's power control declares 0 Off, 1 Standby, 2 Transmit,
+    // 3 Preparing, 4 Fault (see its `descriptions` map). Preparing is the
+    // Radar API's `warming`. Fault has no equivalent, so it reports `off` —
+    // the radar is genuinely unusable, and the fault surfaces via notifications.
+    const cases: Array<[number, string]> = [
+      [0, 'off'],
+      [1, 'standby'],
+      [2, 'transmit'],
+      [3, 'warming'],
+      [4, 'off']
+    ]
+    for (const [value, expected] of cases) {
+      const client = createMockClient({
+        getControls: vi.fn().mockResolvedValue({ power: { value } })
+      })
+      const provider = createRadarProvider(client, createMockApp())
+      const state = await provider.getState?.('radar-0')
+      expect(state?.status, `power=${value}`).toBe(expected)
+    }
+  })
+
+  it('getState reports no state when the power reading is unusable', async () => {
+    // The regression this guards: every value that was not 1 or 2 used to map
+    // to `off`, so a missing control — a transiently failed fetch, a 401 from
+    // an expired session — reported the radar as confidently powered down. An
+    // operator watching a transmitting radar flip to "Off" concludes the radar
+    // died, when only the read did. Returning null surfaces as unknown instead.
+    for (const power of [undefined, null, 'nonsense', 99]) {
+      const client = createMockClient({
+        getControls: vi
+          .fn()
+          .mockResolvedValue(power === undefined ? {} : { power: { value: power } })
+      })
+      const provider = createRadarProvider(client, createMockApp())
+      const state = await provider.getState?.('radar-0')
+      expect(state, `power=${JSON.stringify(power)}`).toBeNull()
+    }
+  })
+
   it('setPower proxies to client', async () => {
     const setControlFn = vi.fn().mockResolvedValue({ success: true })
     const client = createMockClient({


### PR DESCRIPTION
## Summary

`getState` mapped `power === 2` to transmit, `power === 1` to standby, and **everything else** to `off`. That `else` swallowed the failure cases — a missing power control, a transiently failed fetch, a 401 from an expired session — so the plugin asserted the radar was powered down when only the *read* had failed.

This actively misleads. An operator watching a transmitting radar flip to "Off" concludes the radar died and goes looking at the radar rather than the connection. On a live boat it cost two rounds of misdiagnosis before the logs showed the radar transmitting happily throughout, at a steady 12 revolutions per 30 seconds, while the panel said "Off".

Unusable readings now return `null`, which surfaces as unknown rather than as a confident state the plugin cannot substantiate.

The same `else` also hid two real states. mayara's `power` control declares five values in its own `descriptions` map — `0 Off, 1 Standby, 2 Transmit, 3 Preparing, 4 Fault` — so **Preparing**, the magnetron warm-up that the Radar API calls `warming`, was reported as `off` for its entire duration. So was **Fault**. Both are now mapped explicitly; Fault reports `off` because the radar is genuinely unusable and the Radar API enum has no closer term, with the fault itself surfacing through notifications.

## Tested

- `npm run build:all` — 141 tests pass (two new).
- `npm run format:check` — clean.
- The new tests **fail against the previous implementation** with exactly the expected errors: `power=3: expected 'off' to be 'warming'` and `power=undefined: expected { id: 'radar-0', … } to be null`. They verify the fix rather than merely restating it.
- `npm run test:e2e` — 19/19 against a real signalk-server, real mayara-server and a real Furuno DRS4D-NXT. The live radar now correctly reports `status=transmit`.

## Note on review feedback

CodeRabbit raised two findings asking that `status`, `idle` and `explanation` be forwarded from mayara directly instead of derived from `power`. That is the right long-term design — it is written up in `AGENTS.md` under "Radar status model" — but it describes an **unimplemented** model. That section opens by saying it is "**design guidance**, not a description of finished code".

Verified against the running server: mayara currently returns only `brand`, `model`, `name`, `radarIpAddress`, `replay` on `/radars`, and neither `/radars/:id` nor `/capabilities` carries `status`, `idle` or `explanation`. Deriving from `power` is what is possible today. When mayara grows those fields, this plugin should forward them verbatim — that follow-up belongs in mayara first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Maps Mayara power values to accurate radar states, including `warming` and fault handling.

Returns `null` for missing, invalid, or unavailable power readings instead of reporting `off`.

Adds tests for all power-state mappings and failed reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->