### PR TITLE
chore(release): 1.5.0-beta.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "1.5.0-beta.2",
+  "version": "1.5.0-beta.3",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Releases `1.5.0-beta.3`, carrying the radar-status fix from #101.

`getState` used to map every power value that wasn't 1 or 2 to `off`, so a failed read — a missing control, a transient fetch failure, a 401 from an expired session — reported the radar as confidently powered down. On the boat that meant a radar transmitting steadily at 12 revolutions per 30 seconds displayed as "Off", which sent two rounds of diagnosis after the radar and the container instead of the connection.

It now returns unknown when there is no usable reading, and maps the two states the old `else` had hidden: **Preparing** (the magnetron warm-up, `warming` in the Radar API) and **Fault**.

Still a beta for the same reason as beta.1 and beta.2: signalk-server 2.31.0, which carries the v3.4.0 Radar API, is not published. Tagging publishes under the `beta` dist-tag, so `latest` stays on 1.4.4.

## Tested

- `npm run build:all` — 141 tests pass.
- `npm run format:check` — clean.
- Confirmed the built artifact carries the fix: `plugin/radar-provider.js` contains the `POWER_TO_STATUS` map including `3: 'warming'`.
- `npm pack --dry-run` — 53 files, correct version.

## Scope

This makes the plugin report honestly; it does not fix the underlying failure. The `/gui/signalk/...` requests that succeed and then return 401 — with `security.json` set to `expiration: NEVER` — are still what breaks `loadRadar()`, which retries every 10s and never reaches the spoke socket. After installing this you should see "unknown" rather than a false "Off", which is correct but still not a working picture.
