### PR TITLE
chore(release): 1.5.0-beta.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "1.5.0-beta.3",
+  "version": "1.5.0-beta.4",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Beta release covering #103.

The radar GUI now opens directly on mayara-server's own port by default, rather than through this plugin's reverse proxy.

**This changes behaviour on upgrade, not only for new installs.** Existing configurations adopt the new default. Disable **Open the radar GUI directly on mayara-server** to keep using the proxy, which is still needed when:

- mayara-server's port is not reachable from the browser, or
- Signal K is served over TLS and the radar session should be encrypted too — the direct GUI follows its own **Use HTTPS/WSS** setting.

The AIS overlay is unaffected either way: mayara-server relays vessels from Signal K into its own store.

## Tested

- `npm run build:all` — lint, build, 149 tests passing