### PR TITLE
fix(radar): send compound control payloads to mayara unwrapped

### DIFF
--- a/plugin/mayara-client.js
+++ b/plugin/mayara-client.js
@@ -71,7 +71,13 @@ export class MayaraClient {
         return (await this.request('GET', `${API_BASE}/${radarId}/controls`));
     }
     async setControl(radarId, controlId, value) {
-        return this.request('PUT', `${API_BASE}/${radarId}/controls/${controlId}`, { value });
+        // A scalar gets the Signal K `{ value }` envelope; a compound payload is
+        // already the body mayara expects and must go through as-is. Wrapping it
+        // unconditionally produced `{ value: { enabled: …, endDistance: … } }`,
+        // which mayara rejects with "Cannot control 'guardZone2' to value {…}" —
+        // so guard zones and no-transmit sectors could not be set at all.
+        const body = value !== null && typeof value === 'object' && !Array.isArray(value) ? value : { value };
+        return this.request('PUT', `${API_BASE}/${radarId}/controls/${controlId}`, body);
     }
     async setControls(radarId, controls) {
         return this.request('PUT', `${API_BASE}/${radarId}/controls`, controls);

--- a/src/mayara-client.ts
+++ b/src/mayara-client.ts
@@ -89,7 +89,14 @@ export class MayaraClient {
   }
 
   async setControl(radarId: string, controlId: string, value: unknown): Promise<unknown> {
-    return this.request('PUT', `${API_BASE}/${radarId}/controls/${controlId}`, { value })
+    // A scalar gets the Signal K `{ value }` envelope; a compound payload is
+    // already the body mayara expects and must go through as-is. Wrapping it
+    // unconditionally produced `{ value: { enabled: …, endDistance: … } }`,
+    // which mayara rejects with "Cannot control 'guardZone2' to value {…}" —
+    // so guard zones and no-transmit sectors could not be set at all.
+    const body =
+      value !== null && typeof value === 'object' && !Array.isArray(value) ? value : { value }
+    return this.request('PUT', `${API_BASE}/${radarId}/controls/${controlId}`, body)
   }
 
   async setControls(radarId: string, controls: Record<string, unknown>): Promise<unknown> {

--- a/test/mayara-client.test.ts
+++ b/test/mayara-client.test.ts
@@ -70,6 +70,33 @@ describe('MayaraClient', () => {
     expect(JSON.parse(receivedBody)).toEqual({ value: 'transmit' })
   })
 
+  it('sends a compound control payload unwrapped', async () => {
+    // A guard zone's `value` is its start bearing, one field among several.
+    // Wrapping it again would produce { value: { enabled, endValue, … } },
+    // which mayara rejects — so zones and sectors could not be set at all.
+    let receivedBody = ''
+    serverPort = await createTestServer((req, res) => {
+      expect(req.method).toBe('PUT')
+      expect(req.url).toBe('/signalk/v2/api/vessels/self/radars/radar-0/controls/guardZone1')
+      req.on('data', (chunk: string) => (receivedBody += chunk))
+      req.on('end', () => {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ success: true }))
+      })
+    })
+
+    const zone = {
+      enabled: true,
+      value: -0.5585,
+      endValue: 1.7104,
+      startDistance: 100,
+      endDistance: 500
+    }
+    const client = new MayaraClient({ host: 'localhost', port: serverPort })
+    await client.setControl('radar-0', 'guardZone1', zone)
+    expect(JSON.parse(receivedBody)).toEqual(zone)
+  })
+
   it('rejects on HTTP error status', async () => {
     serverPort = await createTestServer((req, res) => {
       res.writeHead(404)


### PR DESCRIPTION
## Summary

- `setControl` wrapped every payload in the Signal K `{ value }` envelope. Correct for a scalar, wrong for a compound control: a guard zone or no-transmit sector already arrives as the body mayara expects, so wrapping produced `{ value: { enabled: …, endValue: …, startDistance: … } }` and mayara answered `400 Cannot control 'guardZone2' to value {…}`. Zones and sectors could not be set through the plugin at all.
- Wrap only a scalar; pass an object through as-is.
- This is one half of the fix. SignalK/signalk-server#2935 is the other: the Radar API discarded a compound control’s sibling fields before the provider was ever called, so a zone PUT reached this client as a bare bearing — which kept this bug hidden. Neither fix is much use without the other.

## Tested

- New unit test asserting a five-field guard-zone payload reaches the wire unwrapped; the existing scalar test still asserts the `{ value }` envelope. `npm run build:all` green, 150 tests.
- Reproduced against mayara-server 3.8.1 with a Navico HALO24 before fixing: a compound PUT that signalk-server forwarded whole came back `400 Cannot control ...`, while the identical body sent straight to mayara returned `200` and applied all five fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates radar control payload handling to wrap scalar values in `{ value }` while sending compound objects unchanged. Preserves guard-zone and no-transmit-sector fields and prevents rejected requests.

Adds test coverage for unwrapped guard-zone payloads while retaining scalar envelope behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->