### PR TITLE
chore(release): 1.5.0-beta.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marineyachtradar/signalk-plugin",
-  "version": "1.5.0-beta.4",
+  "version": "1.5.0-beta.5",
   "description": "MaYaRa Radar - Connect SignalK to mayara-server",
   "main": "plugin/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

Version bump only. Ships the one fix merged since `1.5.0-beta.4`:

- **#105** — compound radar controls (guard zones, no-transmit sectors) could not be set through this plugin at all. `setControl` wrapped every payload in the Signal K `{ value }` envelope, which is right for a scalar but produced `{ value: { enabled, endValue, startDistance, … } }` for a compound control, and mayara-server rejected it with `400 Cannot control 'guardZone2' to value {…}`. Scalar controls were unaffected.

**Requires signalk-server 2.31.0-beta.2 or newer** for the matching Radar API fix (SignalK/signalk-server#2935). Before that, the server discarded a compound control's sibling fields before the provider was ever called, so a guard-zone PUT reached this plugin carrying only its start bearing — the two fixes are only useful together.

## Tested

Verified on a Navico HALO24 via mayara-server 3.8.1 and signalk-server 2.31.0-beta.2, with this build deployed to the pi. A 30-case control-write matrix covering compound and scalar writes over both the Signal K API (:3000) and mayara directly (:6502) passes end to end, with every write read back from mayara rather than trusted from the response:

- guard zone (5 fields), no-transmit sector (3 fields), gain `{auto,value}` — all fields land
- scalar range, enum mode, `/gain` and `/range` shortcut routes
- bulk `PUT /radars/{id}` and mayara's `PUT /controls`
- negative cases: unknown control rejected, duplicate control rejected

Before this fix the same guard-zone write returned `400` from mayara; before #2935 it returned `200` while silently discarding four of five fields.