### PR TITLE
refactor: name the forwarder for what it forwards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ plugin/*.js
 plugin/*.js.map
 plugin/*.d.ts
 plugin/*.d.ts.map
+
+# Per-developer Makefile extensions; never committed
+Makefile.local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ The plugin is a **thin proxy**: it registers as a Radar API provider, forwards c
 - `mayara-client.ts` — HTTP(S) client for mayara's `/signalk/v2/api/vessels/self/radars/*` (list, capabilities, controls, targets). No protocol logic, just request plumbing.
 - `radar-provider.ts` — implements `radar.RadarProviderMethods`, registered with the server via `app.radarApi.register(PLUGIN_ID, …)`. Translates Radar API calls into `MayaraClient` requests.
 - `spoke-forwarder.ts` — one per radar; a WebSocket client that pipes mayara's binary spoke stream into `app.binaryStreamManager.emitData('radars/<id>', buf)`. Reconnects with backoff.
-- `notification-forwarder.ts` — subscribes to `notifications.*` on mayara's Signal K **v1** stream and republishes the deltas upstream via `app.handleMessage()` (e.g. guard-zone alarms). Filters out non-notification paths.
+- `delta-forwarder.ts` — subscribes to mayara's Signal K **v1** stream and republishes the deltas upstream via `app.handleMessage()`, keeping the value entries whose path starts with one of the configured prefixes. Configured in `index.ts` with `notifications.` (guard-zone alarms) and `radars.` (control and target state); the defaults are notifications alone.
 - `gui-proxy-path.ts` — the pure `rewriteGuiProxyPath` used by the GUI reverse proxy: `/signalk…` and `/v2…` pass straight through to mayara, everything else gets `/gui` prepended for the static asset server.
 - `signalk-token.ts` — the device-access-request flow (POST request, poll for approval, validate) plus token-cache file helpers.
 - `config/schema.ts` — `ConfigSchema` (the Admin-UI form) and `SCHEMA_DEFAULTS` (the runtime default merge — see the gotcha below).

--- a/docs/api-divergence.md
+++ b/docs/api-divergence.md
@@ -53,7 +53,7 @@ reconciled.
 | spoke-length field                        | `maxSpokeLength`                                        | list: `maxSpokeLen`; capabilities: `maxSpokeLength`                                                                               | —                                                                                                                      |
 | `capabilities`                            | spec format                                             | same spec format (incl. `legend.pixels`)                                                                                          | proxied                                                                                                                |
 | **spoke stream** (binary, `spokeDataUrl`) | `…/radars/{id}/spokes` binary protobuf WS               | binary forwarding **implemented but mis-pathed at `…/radars/{id}/stream`** (`src/api/streams/index.ts`), not the spec's `/spokes` | emits into `binaryStreamManager` (streamId `radars/{id}`) — client-exposed by that endpoint                            |
-| **control stream** (JSON, `streamUrl`)    | `radars.{id}.controls.*` deltas on `/signalk/v1/stream` | the standard SK delta/PUT stream **already exists**; it just carries no `radars.*` yet                                            | subscribes to mayara's v1 stream but **filters to notifications only** — radar deltas not republished, no PUT handlers |
+| **control stream** (JSON, `streamUrl`)    | `radars.{id}.controls.*` deltas on `/signalk/v1/stream` | the standard SK delta/PUT stream **already exists**; it carries whatever a provider republishes onto it                           | subscribes to mayara's v1 stream and republishes `notifications.*` and `radars.*`; PUT handlers registered per control |
 
 Re-verified 2026-07-19 against the current `../signalk-server` tree (`radar_api.md`
 last touched Jun 21, commit `9cd2ebe0` "Radar API refactored"; impl predates it):
@@ -97,12 +97,11 @@ lives in a _different_ module than the radar API:
 plugin-side.** Signal K's `/signalk/v1/stream` already does deltas (out) and PUTs
 (in); the gap is purely that radar data is not bridged across it:
 
-- **mayara → SK (state out).** The plugin already connects to mayara's v1 stream
-  but `notification-forwarder.ts` **filters to `notifications.*`**, so SK's
-  `/signalk/v1/stream` carries **no `radars.*` paths** (verified: 98 messages, none).
-  Widening the forwarder to also republish `radars.*` deltas via
-  `app.handleMessage()` (stamping the proper `context`) surfaces live radar state
-  to every SK subscriber.
+- **mayara → SK (state out).** `delta-forwarder.ts` subscribes to
+  `notifications.*` and `radars.*` on mayara's v1 stream and republishes both via
+  `app.handleMessage()`, so SK's `/signalk/v1/stream` and data model carry
+  `radars.{id}.controls.*` and `radars.{id}.targets.*`. Targets depend on mayara
+  answering a `radars.*` subscription with them, which it does from 3.8.2.
 - **SK → mayara (control in).** A client changes a control with a Signal K PUT
   (over the v1 stream or REST). The plugin registers
   `app.registerPutHandler('vessels.self', 'radars.<id>.controls.<control>', …)`
@@ -256,11 +255,11 @@ streamUrl }`. The fields dropped from the list — `status`, `range`, `controls`
    working transport, not new infrastructure. (b) **Control `/signalk/v1/stream`** —
    **no signalk-server endpoint is needed**: SK's v1 stream already does deltas (out)
    and PUTs (in), and mayara already models controls as `radars.{id}.controls.*` on
-   its own v1 stream (observed 2026-07-20). The gap is purely the plugin-side bridge:
-   widen `notification-forwarder.ts` (currently `notifications.*`-only) to also
-   republish `radars.*` deltas, and register `app.registerPutHandler(...)` for
-   `radars.<id>.controls.*` that forwards to mayara's control PUT. Also fix the stale
-   `radar/index.ts:812` note to reference `/spokes` and `/signalk/v1/stream`.
+   its own v1 stream (observed 2026-07-20). The plugin-side bridge carries it:
+   `delta-forwarder.ts` republishes `radars.*` alongside `notifications.*`, and
+   `app.registerPutHandler(...)` is registered for `radars.<id>.controls.*`
+   forwarding to mayara's control PUT. The stale `radar/index.ts:812` note still
+   refers to the wrong paths.
 5. **Field naming.** `maxSpokeLength` consistently (it leaves the list entirely and
    lives only in `/capabilities`, where it is already spelled `maxSpokeLength`, so the
    `maxSpokeLen` spelling disappears with the lean list).
@@ -283,8 +282,8 @@ current rich array, and the reason the `#2357` refactor went the other way.
 | 2   | `signalk-server` `src/api/radar/index.ts`                                           | `getRadars()` builds the keyed `{ version, radars }` object; stop cramming state into list entries                                                                                                                              | todo                                                    |
 | 3   | `signalk-server` `src/api/radar/openApi.ts`                                         | Wrap the list response; it is already lean, so mostly response-envelope alignment                                                                                                                                               | todo                                                    |
 | 4a  | `signalk-server` `src/api/streams/index.ts` + `src/api/radar/asyncApi.ts`           | Move the binary spoke forwarding from `/stream` to `/spokes` on the upgrade listener; realign `asyncApi.ts`; fix the stale `radar/index.ts:812` note                                                                            | todo                                                    |
-| 4b  | **this plugin** `notification-forwarder.ts` (or a new forwarder)                    | Widen the mayara→SK forwarder to republish `radars.*` deltas, not just `notifications.*`, so radar state appears on SK's `/signalk/v1/stream`                                                                                   | todo                                                    |
-| 4c  | **this plugin** `src/index.ts` + `radar-provider.ts`                                | Register `app.registerPutHandler` for `radars.<id>.controls.*` → forward to mayara control PUT (SK→mayara control-in)                                                                                                           | todo                                                    |
+| 4b  | **this plugin** `delta-forwarder.ts`                                                | Widen the mayara→SK forwarder to republish `radars.*` deltas, not just `notifications.*`, so radar state appears on SK's `/signalk/v1/stream`                                                                                   | done                                                    |
+| 4c  | **this plugin** `src/index.ts` + `radar-provider.ts`                                | Register `app.registerPutHandler` for `radars.<id>.controls.*` → forward to mayara control PUT (SK→mayara control-in)                                                                                                           | done                                                    |
 | 5   | **this plugin** `src/radar-provider.ts` + tests                                     | `getRadarInfo` returns the lean object (`name`/`brand`/`model?`/`radarIpAddress`); may omit `spokeDataUrl`/`streamUrl` so clients use signalk-server's forwarded endpoints; status/range/controls already covered by `getState` | todo                                                    |
 
 Per this repo's PR discipline these are separate PRs, sequenced server-api →

--- a/src/delta-forwarder.ts
+++ b/src/delta-forwarder.ts
@@ -6,12 +6,12 @@ import type { Delta } from '@signalk/server-api'
  * minimum so the unit tests can pass a stub without dragging in the full
  * server-api types.
  */
-export interface NotificationForwarderApp {
+export interface DeltaForwarderApp {
   handleMessage(id: string, msg: Partial<Delta>): void
   debug?(msg: string): void
 }
 
-export interface NotificationForwarderOptions {
+export interface DeltaForwarderOptions {
   /**
    * Plugin id used when calling `app.handleMessage`. Signal K stamps
    * the republished delta's `$source` from this; passing the same id
@@ -64,7 +64,7 @@ export interface NotificationForwarderOptions {
  * shaped it to the SK spec — and the SK server stamps `$source` from
  * `pluginId` and `context` = self on republish.
  */
-export class NotificationForwarder {
+export class DeltaForwarder {
   private readonly pluginId: string
   private readonly url: string
   private readonly subscriptions: Array<{ path: string; policy: string }>
@@ -77,9 +77,9 @@ export class NotificationForwarder {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
   private closed = false
   private connected = false
-  private readonly app: NotificationForwarderApp
+  private readonly app: DeltaForwarderApp
 
-  constructor(app: NotificationForwarderApp, options: NotificationForwarderOptions) {
+  constructor(app: DeltaForwarderApp, options: DeltaForwarderOptions) {
     this.app = app
     this.pluginId = options.pluginId
     this.url = options.url
@@ -99,7 +99,7 @@ export class NotificationForwarder {
   private connect(): void {
     if (this.closed) return
 
-    this.debug(`Connecting to notification stream: ${this.url}`)
+    this.debug(`Connecting to the mayara stream: ${this.url}`)
 
     try {
       const ws = this.webSocketFactory(this.url)
@@ -107,7 +107,7 @@ export class NotificationForwarder {
 
       ws.on('open', () => {
         this.connected = true
-        this.debug('Connected to mayara notification stream')
+        this.debug('Connected to the mayara stream')
 
         // Tell mayara which deltas we want. Wildcards mean we pick up every
         // radar's alarms/state without having to know radar ids up front.
@@ -118,7 +118,7 @@ export class NotificationForwarder {
           ws.send(subscription)
         } catch (err) {
           this.debug(
-            `Failed to send notification subscription: ${err instanceof Error ? err.message : String(err)}`
+            `Failed to send subscription: ${err instanceof Error ? err.message : String(err)}`
           )
         }
       })
@@ -129,28 +129,28 @@ export class NotificationForwarder {
 
       ws.on('error', (err: Error) => {
         this.connected = false
-        this.debug(`Notification stream error: ${err.message}`)
+        this.debug(`mayara stream error: ${err.message}`)
       })
 
       ws.on('close', (code: number) => {
         this.connected = false
-        this.debug(`Notification stream closed: ${code}`)
+        this.debug(`mayara stream closed: ${code}`)
         if (!this.closed) {
           this.scheduleReconnect()
         }
       })
     } catch (err) {
       this.debug(
-        `Failed to connect to notification stream: ${err instanceof Error ? err.message : String(err)}`
+        `Failed to connect to the mayara stream: ${err instanceof Error ? err.message : String(err)}`
       )
       this.scheduleReconnect()
     }
   }
 
   /**
-   * Parse one inbound text frame and forward every notification-pathed
+   * Parse one inbound text frame and forward every subscribed-path
    * value entry to the host SK server. Non-text frames, non-JSON
-   * payloads, deltas with no notification entries, and the upstream
+   * payloads, deltas with nothing at a subscribed path, and the upstream
    * "hello" handshake are all silently dropped.
    *
    * Exposed `protected` so the tests can inject frames without going
@@ -226,7 +226,7 @@ export class NotificationForwarder {
   private scheduleReconnect(): void {
     if (this.closed || this.reconnectTimer) return
 
-    this.debug(`Scheduling notification stream reconnect in ${this.reconnectMs}ms`)
+    this.debug(`Scheduling reconnect to the mayara stream in ${this.reconnectMs}ms`)
 
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null
@@ -258,7 +258,7 @@ export class NotificationForwarder {
     }
 
     this.connected = false
-    this.debug('Stopped notification forwarder')
+    this.debug('Stopped delta forwarder')
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import { MayaraClient } from './mayara-client.js'
 import { rewriteGuiProxyPath } from './gui-proxy-path.js'
 import { createRadarProvider } from './radar-provider.js'
 import { SpokeForwarder } from './spoke-forwarder.js'
-import { NotificationForwarder } from './notification-forwarder.js'
+import { DeltaForwarder } from './delta-forwarder.js'
 import {
   ContainerConfig,
   ContainerManagerApi,
@@ -86,7 +86,7 @@ export default function (app: MayaraServerAPI): Plugin {
   // Single instance: mayara emits notifications on the server-wide v1
   // stream, not per-radar, so we only need one connection regardless of
   // how many radars are discovered.
-  let notificationForwarder: NotificationForwarder | null = null
+  let deltaForwarder: DeltaForwarder | null = null
   let discoveryInterval: ReturnType<typeof setInterval> | null = null
   // Monotonic generation for the token-acquisition loop. Bumped on every
   // start() and stop(); each recovery loop captures the value at launch and
@@ -163,9 +163,9 @@ export default function (app: MayaraServerAPI): Plugin {
       spokeForwarders.clear()
       knownRadars.clear()
 
-      if (notificationForwarder) {
-        notificationForwarder.stop()
-        notificationForwarder = null
+      if (deltaForwarder) {
+        deltaForwarder.stop()
+        deltaForwarder = null
       }
 
       if (client) {
@@ -420,8 +420,8 @@ export default function (app: MayaraServerAPI): Plugin {
             radarId: id,
             connected: spokeForwarders.get(id)?.isConnected() ?? false
           })),
-          notificationForwarder: {
-            connected: notificationForwarder?.isConnected() ?? false
+          deltaForwarder: {
+            connected: deltaForwarder?.isConnected() ?? false
           },
           container: {
             state: containerState,
@@ -1169,12 +1169,13 @@ export default function (app: MayaraServerAPI): Plugin {
       }
     }
 
-    // Bring up the notification forwarder before discovery so the very
-    // first guard-zone alarm a radar fires reaches the upstream Signal
-    // K server. The forwarder owns its own reconnect loop, so failing
-    // here just means it'll reach mayara on a later attempt.
-    if (!notificationForwarder) {
-      notificationForwarder = new NotificationForwarder(app, {
+    // Bring the forwarder up before discovery so the very first thing a
+    // radar says — a guard-zone alarm, a control value — reaches the
+    // upstream Signal K server. The forwarder owns its own reconnect
+    // loop, so failing here just means it'll reach mayara on a later
+    // attempt.
+    if (!deltaForwarder) {
+      deltaForwarder = new DeltaForwarder(app, {
         pluginId: PLUGIN_ID,
         url: client.getStateStreamUrl(),
         // Relay both guard-zone notifications and radar control/target state
@@ -1190,7 +1191,7 @@ export default function (app: MayaraServerAPI): Plugin {
         debug: app.debug.bind(app),
         reconnectInterval: (settings.reconnectInterval || 5) * 1000
       })
-      notificationForwarder.start()
+      deltaForwarder.start()
     }
 
     await connectAndDiscover(settings)

--- a/src/mayara-client.ts
+++ b/src/mayara-client.ts
@@ -133,7 +133,7 @@ export class MayaraClient {
   }
 
   /**
-   * mayara's Signal K v1 stream. Used by NotificationForwarder to relay
+   * mayara's Signal K v1 stream. Used by DeltaForwarder to relay
    * `notifications.*` and `radars.*` deltas upstream.
    *
    * `?subscribe=none` is deliberate: under Signal K's subscription model the

--- a/test/delta-forwarder.test.ts
+++ b/test/delta-forwarder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { NotificationForwarder } from '../src/notification-forwarder.js'
+import { DeltaForwarder } from '../src/delta-forwarder.js'
 import http from 'http'
 import { WebSocketServer, WebSocket } from 'ws'
 
@@ -31,7 +31,7 @@ function makeApp() {
   }
 }
 
-describe('NotificationForwarder', () => {
+describe('DeltaForwarder', () => {
   it('subscribes to notifications.* on connect', async () => {
     const port = await createWsServer()
     const app = makeApp()
@@ -45,7 +45,7 @@ describe('NotificationForwarder', () => {
       })
     })
 
-    const forwarder = new NotificationForwarder(app, {
+    const forwarder = new DeltaForwarder(app, {
       pluginId: 'test-plugin',
       url: `ws://localhost:${port}`,
       reconnectInterval: 100
@@ -67,7 +67,7 @@ describe('NotificationForwarder', () => {
       wss?.on('connection', resolve)
     })
 
-    const forwarder = new NotificationForwarder(app, {
+    const forwarder = new DeltaForwarder(app, {
       pluginId: 'test-plugin',
       url: `ws://localhost:${port}`,
       reconnectInterval: 100
@@ -118,7 +118,7 @@ describe('NotificationForwarder', () => {
       wss?.on('connection', resolve)
     })
 
-    const forwarder = new NotificationForwarder(app, {
+    const forwarder = new DeltaForwarder(app, {
       pluginId: 'test-plugin',
       url: `ws://localhost:${port}`,
       reconnectInterval: 100
@@ -163,7 +163,7 @@ describe('NotificationForwarder', () => {
       wss?.on('connection', resolve)
     })
 
-    const forwarder = new NotificationForwarder(app, {
+    const forwarder = new DeltaForwarder(app, {
       pluginId: 'test-plugin',
       url: `ws://localhost:${port}`,
       reconnectInterval: 100
@@ -194,7 +194,7 @@ describe('NotificationForwarder', () => {
       wss?.on('connection', resolve)
     })
 
-    const forwarder = new NotificationForwarder(app, {
+    const forwarder = new DeltaForwarder(app, {
       pluginId: 'test-plugin',
       url: `ws://localhost:${port}`,
       reconnectInterval: 100
@@ -219,7 +219,7 @@ describe('NotificationForwarder', () => {
     vi.useFakeTimers()
     try {
       const app = makeApp()
-      const forwarder = new NotificationForwarder(app, {
+      const forwarder = new DeltaForwarder(app, {
         pluginId: 'test-plugin',
         url: 'ws://localhost:1',
         reconnectInterval: 50
@@ -249,7 +249,7 @@ describe('NotificationForwarder', () => {
       })
     })
 
-    const forwarder = new NotificationForwarder(app, {
+    const forwarder = new DeltaForwarder(app, {
       pluginId: 'test-plugin',
       url: `ws://localhost:${port}`
     })


### PR DESCRIPTION
`NotificationForwarder` does not forward notifications. It forwards whichever paths it is configured with, and `index.ts` has configured it with `radars.` alongside `notifications.` since radar state started reaching Signal K:

```ts
subscriptions: [{ path: 'notifications.*' }, { path: 'radars.*' }],
pathPrefixes: ['notifications.', 'radars.'],
```

The name cost real time this week. A missing `radars.{id}.targets.*` subtree on the host Signal K server was attributed to this plugin filtering targets out — reasonable, given the class name, the file name, and `AGENTS.md` saying "Filters out non-notification paths". It filters nothing of the sort. The actual cause was on the mayara side, where a `radars.*` subscription returned controls alone, so no target ever arrived here to forward (MarineYachtRadar/mayara-server#545).

## What changed

- `NotificationForwarder` → `DeltaForwarder`, with `…App` / `…Options` to match
- `src/notification-forwarder.ts` → `src/delta-forwarder.ts`, and its test alongside
- log lines that called mayara's stream "the notification stream" now name it for what it is
- the `handleMessage` doc comment described dropping "deltas with no notification entries"; it drops deltas with nothing at a subscribed path

The class doc was already accurate — it said the paths are configurable. Every other mention contradicted it, which is the part worth fixing.

## Documentation corrected

`AGENTS.md` and `docs/api-divergence.md` still described the notifications-only behaviour, including a claim verified against an older build:

> but `notification-forwarder.ts` **filters to `notifications.*`**, so SK's `/signalk/v1/stream` carries **no `radars.*` paths** (verified: 98 messages, none)

That is no longer true, and the divergence table's items 4b and 4c (widen the forwarder, register PUT handlers) are both done in the code. Marked as such.

## Behaviour

None. Rename and prose only — no configuration, defaults or filtering logic touched. 150 tests pass, `tsc --noEmit` clean, eslint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Renames `NotificationForwarder` to `DeltaForwarder` across source files, tests, logs, and documentation.

Updates documentation to describe forwarding for both `notifications.*` and `radars.*` paths, including radar control PUT handling.

Adds `Makefile.local` targets for building, syncing, and deploying the plugin to a running Signal K container.

Preserves configuration, defaults, filtering logic, and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->